### PR TITLE
fix: Correct release config for pre-release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "gen-orb-mcp"
-version = "0.1.0"
+version = "0.1.0-alpha.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/gen-orb-mcp/Cargo.toml
+++ b/crates/gen-orb-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-orb-mcp"
-version = "0.1.0"
+version = "0.1.0-alpha.0"
 description = "Generate MCP servers from CircleCI orb definitions"
 edition.workspace = true
 authors.workspace = true

--- a/crates/gen-orb-mcp/release.toml
+++ b/crates/gen-orb-mcp/release.toml
@@ -2,6 +2,4 @@ pre-release-commit-message = "chore: Release gen-orb-mcp v{{version}}"
 tag-message = "{{tag_name}}"
 tag-name = "gen-orb-mcp-v{{version}}"
 pre-release-hook = ["./release-hook.sh"]
-pre-release-replacements = [
-    { file = "README.md", search = "gen-orb-mcp = \"\\d+\\.\\d+\\.\\d+\"", replace = "gen-orb-mcp = \"{{version}}\"", exactly = 1 },
-]
+pre-release-replacements = []


### PR DESCRIPTION
## Summary
- Set version to `0.1.0-alpha.0` to allow cargo-release to upgrade to `0.1.0-alpha.1`
- Remove `pre-release-replacements` that referenced a non-existent version string in README.md

## Test plan
- [ ] CI passes validation
- [ ] Release workflow succeeds with `0.1.0-alpha.1`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)