### PR TITLE
fix: Simplify release config for package releases

### DIFF
--- a/crates/gen-orb-mcp/release.toml
+++ b/crates/gen-orb-mcp/release.toml
@@ -1,5 +1,4 @@
-pre-release-commit-message = "chore: Release gen-orb-mcp v{{version}}"
+pre-release-commit-message = "chore: Release gen-orb-mcp"
 tag-message = "{{tag_name}}"
 tag-name = "gen-orb-mcp-v{{version}}"
-pre-release-hook = ["./release-hook.sh"]
 pre-release-replacements = []


### PR DESCRIPTION
## Summary
- Remove `{{version}}` from commit message (not supported for `--package` releases)
- Remove `pre-release-hook` to avoid CHANGELOG generation issues during release

## Test plan
- [ ] CI passes validation
- [ ] Release workflow succeeds with `0.1.0-alpha.1`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)