### PR TITLE
fix: Repair release after partial publish

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -300,9 +300,10 @@ jobs:
       - check_crates_io_version:
           package: << parameters.package >>
       # Step 3: Run cargo release (respects SKIP_PUBLISH)
-      - make_cargo_release:
-          package: << parameters.package >>
-          verbosity: "-vv"
+      # TEMPORARILY DISABLED: Crate already published, skip to test GitHub release step
+      # - make_cargo_release:
+      #     package: << parameters.package >>
+      #     verbosity: "-vv"
       # Step 4: Create GitHub release
       - make_github_release:
           package: << parameters.package >>

--- a/crates/gen-orb-mcp/Cargo.toml
+++ b/crates/gen-orb-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-orb-mcp"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 description = "Generate MCP servers from CircleCI orb definitions"
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

- Update crate version to 0.1.0-alpha.1 to match what was published to crates.io
- Temporarily disable cargo release step so we can test the GitHub release step

## Context

Pipeline 33 successfully published `gen-orb-mcp v0.1.0-alpha.1` to crates.io, but the push back to GitHub failed due to branch protection rules:

```
error: GH013: Repository rule violations found for refs/heads/main.
- Changes must be made through a pull request.
- Required status check "on_success" is expected.
```

## Test plan

- [ ] Merge this PR
- [ ] Trigger release workflow
- [ ] Verify GitHub release step runs successfully
- [ ] Re-enable cargo release step after testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)