### PR TITLE
fix: Correct pcu release command and update pcu version

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -238,9 +238,9 @@ commands:
             pcu_args="<< parameters.verbosity >> release"
 
             if [ "<< parameters.package >>" != "" ]; then
-              pcu_args="$pcu_args --package << parameters.package >>"
+              pcu_args="$pcu_args package << parameters.package >>"
             else
-              pcu_args="$pcu_args --prefix << parameters.prefix >>"
+              pcu_args="$pcu_args version --prefix << parameters.prefix >>"
             fi
 
             if [ "<< parameters.update_prlog >>" = "true" ]; then
@@ -304,7 +304,12 @@ jobs:
       # - make_cargo_release:
       #     package: << parameters.package >>
       #     verbosity: "-vv"
-      # Step 4: Create GitHub release
+      # Step 4: Update pcu to latest version (command not yet in toolkit release)
+      - run:
+          name: Update to latest pcu
+          command: |
+            cargo install --force --git https://github.com/jerus-org/pcu --branch main
+      # Step 5: Create GitHub release
       - make_github_release:
           package: << parameters.package >>
           verbosity: "-vv"


### PR DESCRIPTION
## Summary

- Fix `make_github_release` command to use correct pcu subcommand syntax:
  - `pcu release package <name>` (was `pcu release --package <name>`)
  - `pcu release version --prefix <prefix>` (was `pcu release --prefix <prefix>`)
- Add step to install latest pcu from main branch (v0.6.0 in CI doesn't have `release package` subcommand)

## Context

Pipeline 39 failed because:
1. pcu v0.6.0 doesn't recognize `--package` flag
2. The `release package` subcommand requires a newer pcu version

## Test plan

- [ ] Merge this PR
- [ ] Trigger release workflow
- [ ] Verify pcu installs from main branch
- [ ] Verify GitHub release is created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)