### PR TITLE
fix: Re-enable cargo release and add release-prlog script

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -299,11 +299,10 @@ jobs:
       # Step 2: Check crates.io for recovery scenarios
       - check_crates_io_version:
           package: << parameters.package >>
-      # Step 3: Run cargo release (respects SKIP_PUBLISH)
-      # TEMPORARILY DISABLED: Crate already published, skip to test GitHub release step
-      # - make_cargo_release:
-      #     package: << parameters.package >>
-      #     verbosity: "-vv"
+      # Step 3: Run cargo release (respects SKIP_PUBLISH from check_crates_io_version)
+      - make_cargo_release:
+          package: << parameters.package >>
+          verbosity: "-vv"
       # Step 4: Update pcu to latest version (command not yet in toolkit release)
       - run:
           name: Update to latest pcu

--- a/scripts/release-prlog.sh
+++ b/scripts/release-prlog.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -exo pipefail
+
+# Usage: ./scripts/release-prlog.sh <version>
+# Example: ./scripts/release-prlog.sh 0.1.0
+#
+# PRLOG uses standard v prefix tags (v0.1.0) for workspace releases.
+
+VERSION="${1}"
+DATE=$(date +%Y-%m-%d)
+TAG="v${VERSION}"
+
+if [[ -z "${VERSION}" ]]; then
+    echo "Usage: $0 <version>" >&2
+    exit 1
+fi
+
+# Update PRLOG.md - replace Unreleased with version and date
+sed -i "s/## \[Unreleased\]/## [${VERSION}] - ${DATE}/" PRLOG.md
+
+# Add new Unreleased section after the header
+sed -i "/## \[${VERSION}\]/i ## [Unreleased]\n" PRLOG.md
+
+# Commit and tag
+git add PRLOG.md
+git commit -S -s -m "chore: Release PRLOG v${VERSION}"
+git tag -s -m "${TAG}" "${TAG}"
+
+echo "PRLOG released as ${TAG}"


### PR DESCRIPTION
## Summary

- Re-enable `make_cargo_release` step - the `check_crates_io_version` step sets `SKIP_PUBLISH=true` when the version already exists on crates.io, so cargo release will create the commit and tag without re-publishing
- Add `scripts/release-prlog.sh` for PRLOG workspace releases

## Context

Pipeline 42 failed because:
1. Tag wasn't created (cargo release was disabled)
2. `scripts/release-prlog.sh` script was missing

## Test plan

- [ ] Merge this PR
- [ ] Trigger release workflow
- [ ] Verify cargo release creates tag (skips publish since already on crates.io)
- [ ] Verify GitHub release is created
- [ ] Verify PRLOG release step completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)