### PR TITLE
chore: Update Cargo.lock to match version 0.1.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "gen-orb-mcp"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
## Summary

Update Cargo.lock to reflect version 0.1.0-alpha.1 (was still showing 0.1.0-alpha.0).

## Context

Release pipeline failed because cargo release detected uncommitted Cargo.lock changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)