### PR TITLE
fix: Bootstrap workspace versioning with v0.1.0

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -340,6 +340,21 @@ jobs:
             set -exo pipefail
             chmod +x scripts/*.sh
 
+            # Check if any v* tag exists (bootstrap detection)
+            if ! git tag -l 'v*' | grep -q .; then
+              echo "No v* tag found - checking for bootstrap version in PRLOG.md"
+              # Extract first version from PRLOG.md (bootstrap case)
+              BOOTSTRAP_VERSION=$(grep -oP '## \[\K[0-9]+\.[0-9]+\.[0-9]+' PRLOG.md | head -1 || echo "")
+              if [ -n "$BOOTSTRAP_VERSION" ]; then
+                echo "Bootstrap: Creating initial tag v${BOOTSTRAP_VERSION}"
+                git tag -s -m "v${BOOTSTRAP_VERSION}" "v${BOOTSTRAP_VERSION}"
+                git push origin main --tags
+                exit 0
+              fi
+              echo "No bootstrap version found in PRLOG.md"
+              exit 0
+            fi
+
             # Use standard v prefix for PRLOG
             BUMP=$(nextsv calculate --prefix "v" 2>/dev/null || echo "none")
 

--- a/PRLOG.md
+++ b/PRLOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-01-26
+
 ### Changed
 
 - chore-Update Cargo.lock to match version 0.1.0-alpha.1(pr [#10])


### PR DESCRIPTION
## Summary

- Mark existing PRs as released under `v0.1.0` in PRLOG.md
- Add bootstrap detection in `release-prlog` job to create initial `v*` tag when none exists

## Context

The workspace versioning (`v<VERSION>` tags) needs a foundation to work. This PR:
1. Establishes `v0.1.0` as the first workspace release containing PRs #4-#10
2. Updates `release-prlog` job to detect when no `v*` tag exists and bootstrap from PRLOG.md

After this PR merges, the release workflow will create the `v0.1.0` tag, enabling `nextsv` to calculate future versions.

## Test plan

- [ ] Merge this PR
- [ ] Verify release workflow creates `v0.1.0` tag
- [ ] Future releases should automatically increment workspace version

🤖 Generated with [Claude Code](https://claude.com/claude-code)