### PR TITLE
fix: Skip GitHub release if already exists

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -281,6 +281,19 @@ commands:
               exit 0
             fi
 
+            # Determine the tag name
+            if [ "<< parameters.package >>" != "" ]; then
+              TAG="<< parameters.package >>-v${VERSION}"
+            else
+              TAG="<< parameters.prefix >>${VERSION}"
+            fi
+
+            # Check if GitHub release already exists
+            if gh release view "$TAG" > /dev/null 2>&1; then
+              echo "GitHub release ${TAG} already exists - skipping"
+              exit 0
+            fi
+
             pcu_args="<< parameters.verbosity >> release"
 
             if [ "<< parameters.package >>" != "" ]; then


### PR DESCRIPTION
## Summary

Add check to skip GitHub release creation if it already exists, using `gh release view`.

## Context

Release workflow failed because the GitHub release for `gen-orb-mcp-v0.1.0-alpha.1` already exists. This adds the same resilience pattern used for tag and crates.io checks.

## Test plan

- [ ] Merge this PR  
- [ ] Release workflow should skip existing GitHub release
- [ ] PRLOG bootstrap step should run

🤖 Generated with [Claude Code](https://claude.com/claude-code)