### PR TITLE
fix: Use GitHub API to check for existing release

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -288,11 +288,21 @@ commands:
               TAG="<< parameters.prefix >>${VERSION}"
             fi
 
-            # Check if GitHub release already exists
-            if gh release view "$TAG" > /dev/null 2>&1; then
+            # Check if GitHub release already exists using API
+            # Extract owner/repo from git remote
+            REPO_URL=$(git remote get-url origin)
+            REPO_PATH=$(echo "$REPO_URL" | sed -E 's|.*github\.com[:/]||' | sed 's|\.git$||')
+
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              -H "Authorization: token ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${REPO_PATH}/releases/tags/${TAG}")
+
+            if [ "$HTTP_STATUS" = "200" ]; then
               echo "GitHub release ${TAG} already exists - skipping"
               exit 0
             fi
+            echo "GitHub release ${TAG} not found (HTTP ${HTTP_STATUS}) - will create"
 
             pcu_args="<< parameters.verbosity >> release"
 


### PR DESCRIPTION
## Summary

Replace `gh release view` with direct GitHub API call using curl and `GITHUB_TOKEN` for more reliable release existence check.

## Context

The `gh` CLI wasn't properly detecting the existing release, possibly due to authentication or configuration issues in CI. Using the GitHub API directly with the available `GITHUB_TOKEN` is more reliable.

## Test plan

- [ ] Merge this PR
- [ ] Release workflow should detect existing GitHub release via API
- [ ] Should skip to PRLOG bootstrap step

🤖 Generated with [Claude Code](https://claude.com/claude-code)