### PR TITLE
chore: Use nextsv for version calculation

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -445,13 +445,11 @@ workflows:
     jobs:
       - tools
 
-      # Release gen-orb-mcp crate
-      # For pre-release, specify version parameter
+      # Release gen-orb-mcp crate (version calculated by nextsv)
       - release-crate:
           name: release-gen-orb-mcp
           requires: [tools]
           package: gen-orb-mcp
-          version: "0.1.0-alpha.1"
           context:
             - release
             - bot-check


### PR DESCRIPTION
## Summary

Remove hardcoded version parameter from release workflow. Now that base tags are established (`gen-orb-mcp-v0.1.0-alpha.1` and `v0.1.0`), nextsv can calculate the next version based on conventional commits.

## How it works

- `nextsv calculate --package gen-orb-mcp` will determine if a release is needed
- If no releasable changes in `crates/gen-orb-mcp/`, returns "none" and release is skipped
- If changes exist, calculates appropriate semver bump (patch/minor/major)

🤖 Generated with [Claude Code](https://claude.com/claude-code)