### PR TITLE
chore: set explicit version 0.1.0 for release

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -518,11 +518,14 @@ workflows:
           type: approval
           requires: [calculate-versions]
 
-      # Release gen-orb-mcp crate (version calculated by nextsv)
+      # Release gen-orb-mcp crate
+      # Note: version specified explicitly for 0.1.0 release from pre-release
+      # Remove 'version' parameter after this release to resume auto-detection
       - release-crate:
           name: release-gen-orb-mcp
           requires: [approve-release]
           package: gen-orb-mcp
+          version: "0.1.0"
           context:
             - release
             - bot-check


### PR DESCRIPTION
## Summary

- Set explicit version `0.1.0` for the release workflow
- nextsv cannot calculate version from pre-release tag (`gen-orb-mcp-v0.1.0-alpha.1`)

## Action Required

After this PR is merged and the 0.1.0 release is complete, the `version: "0.1.0"` parameter should be removed from the release workflow to resume auto-detection.

## Test plan

- [ ] CI passes
- [ ] Release workflow will use explicit version 0.1.0

🤖 Generated with [Claude Code](https://claude.ai/code)