### PR TITLE
fix: pull latest main in release-prlog before pushing

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -559,7 +559,11 @@ jobs:
 
             # Check if tag already exists
             TAG="v${VERSION}"
-            git fetch --tags
+            git fetch --tags origin main
+
+            # Pull latest main (release-crate may have pushed commits)
+            git pull --rebase origin main
+
             if git tag -l "$TAG" | grep -q .; then
               echo "Tag $TAG already exists - updating PRLOG without new tag"
               # Update PRLOG.md with the release date but don't create new tag


### PR DESCRIPTION
## Summary
- Fix non-fast-forward push error in release-prlog job
- Add `git pull --rebase origin main` after fetching tags

## Problem
The release-crate job pushes commits to main. When release-prlog runs afterward, it checks out an older version of main and can't push its changes because main has moved forward.

## Solution
Pull the latest main (with rebase) before making any changes in release-prlog. This ensures it has the commits from release-crate.

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger the release pipeline with v0.1.0 overrides
- [ ] Verify release-prlog succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)