### PR TITLE
chore: reset version overrides to auto-detect

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -11,12 +11,12 @@ parameters:
   # Set to empty string "" to use nextsv auto-detection
   crate_version_override:
     type: string
-    default: "0.1.0"
+    default: ""
   # Version override for workspace/PRLOG release
   # Set to empty string "" to use nextsv auto-detection
   workspace_version_override:
     type: string
-    default: "0.1.0"
+    default: ""
 
 orbs:
   toolkit: jerus-org/circleci-toolkit@4.2.1


### PR DESCRIPTION
## Summary
- Reset `crate_version_override` to `""`
- Reset `workspace_version_override` to `""`

Now that v0.1.0 is released, future releases will use nextsv auto-detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)