### PR TITLE
feat(ci): add orb CI wiring and orb source

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,25 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
 
+  orb-tools: circleci/orb-tools@12.3.3
+jobs:
+  regenerate-orb:
+    docker:
+      - image: cimg/rust:stable
+    steps:
+      - checkout
+      - run:
+          name: Install gen-circleci-orb
+          command: cargo binstall --no-confirm gen-circleci-orb
+      - run:
+          name: Regenerate orb source
+          command: |
+            gen-circleci-orb generate \
+              --binary gen-orb-mcp \
+              --namespace jerus-org \
+              --orb-dir orb
+
+
 workflows:
   validation:
     jobs:
@@ -78,3 +97,13 @@ workflows:
                 - /pull\/[0-9]+/
                 - main
 
+      - regenerate-orb:
+          requires: [common-tests]
+      - orb-tools/pack:
+          name: pack-orb
+          source_dir: orb/src
+          requires: [regenerate-orb]
+      - orb-tools/review:
+          name: review-orb
+          source_dir: orb/src
+          requires: [pack-orb]

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -13,6 +13,8 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
 
+  orb-tools: circleci/orb-tools@12.3.3
+  docker: circleci/docker@3.2.0
 jobs:
   tools:
     executor: toolkit/rust_env_rolling
@@ -26,6 +28,20 @@ jobs:
             cargo release --version
             rsign --version
 
+  build-container:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: |
+            docker build -t jerusdp/gen-orb-mcp:${CIRCLE_TAG} orb
+      - run:
+          name: Push Docker image
+          command: |
+            docker push jerusdp/gen-orb-mcp:${CIRCLE_TAG}
 workflows:
   release:
     jobs:
@@ -60,3 +76,16 @@ workflows:
             - release
             - bot-check
             - pcu-app
+      - orb-tools/pack:
+          name: pack-orb-release
+          source_dir: orb/src
+          requires: [release-gen-orb-mcp]
+      - build-container:
+          requires: [release-gen-orb-mcp]
+          context: [docker-credentials]
+      - orb-tools/publish:
+          name: publish-orb-jerus-org
+          orb_name: jerus-org/gen-orb-mcp
+          pub_type: production
+          requires: [build-container, pack-orb-release]
+          context: [orb-publishing]

--- a/orb/Dockerfile
+++ b/orb/Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu:24.04
+RUN cargo binstall --no-confirm gen-orb-mcp

--- a/orb/src/@orb.yml
+++ b/orb/src/@orb.yml
@@ -1,0 +1,3 @@
+version: 2.1
+description: >
+  Generate MCP servers from CircleCI orb definitions

--- a/orb/src/commands/diff.yml
+++ b/orb/src/commands/diff.yml
@@ -1,0 +1,23 @@
+description: Compute conformance rules by diffing two orb versions  Compares the current orb against a previous version (read from a file) and emits a JSON array of ConformanceRule values. These rules can be passed to `generate --migrations` to embed migration tooling in the generated MCP server.
+parameters:
+  current:
+    type: string
+    description: Path to the current orb YAML (the new version)
+  previous:
+    type: string
+    description: Path to the previous orb YAML (the old version to diff against)
+  since_version:
+    type: string
+    description: The version string to embed in emitted rules (e.g. "5.0.0")
+  output:
+    type: string
+    description: 'Optional output file for the JSON rules (default: stdout)'
+steps:
+- run:
+    name: diff
+    command: |-
+      gen-orb-mcp diff \
+        --current "<< parameters.current >>" \
+        --previous "<< parameters.previous >>" \
+        --since-version "<< parameters.since_version >>" \
+        --output "<< parameters.output >>"

--- a/orb/src/commands/generate.yml
+++ b/orb/src/commands/generate.yml
@@ -1,0 +1,45 @@
+description: Generate an MCP server from an orb definition
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML file (e.g., src/@orb.yml)
+  output:
+    type: string
+    description: Output directory for generated server
+    default: ./dist
+  format:
+    type: enum
+    description: Output format
+    default: source
+    enum:
+    - binary
+    - source
+  name:
+    type: string
+    description: Name for the generated orb server (defaults to filename)
+  force:
+    type: boolean
+    description: Required for non-interactive CI environments when output exists.
+  migrations:
+    type: string
+    description: Directory containing conformance rule JSON files to embed in the server  All *.json files in this directory are merged and embedded as migration tooling in the generated server. When provided, the server gains plan_migration and apply_migration MCP Tools in addition to Resources.
+  prior_versions:
+    type: string
+    description: .yml` (e.g., `4.7.1.yml`). The generated server will expose version-specific resources for each prior version alongside the current version.
+  tag_prefix:
+    type: string
+    description: Tag prefix used to discover the orb version from git tags  The git repository is derived automatically from --orb-path. Defaults to "v" (matches tags like v6.0.0).
+    default: v
+steps:
+- run:
+    name: generate
+    command: |-
+      gen-orb-mcp generate \
+        --orb-path "<< parameters.orb_path >>" \
+        <<# parameters.output >>--output "<< parameters.output >>"<</ parameters.output >> \
+        <<# parameters.format >>--format "<< parameters.format >>"<</ parameters.format >> \
+        --name "<< parameters.name >>" \
+        <<# parameters.force >>--force<</ parameters.force >> \
+        --migrations "<< parameters.migrations >>" \
+        --prior-versions "<< parameters.prior_versions >>" \
+        <<# parameters.tag_prefix >>--tag-prefix "<< parameters.tag_prefix >>"<</ parameters.tag_prefix >>

--- a/orb/src/commands/migrate.yml
+++ b/orb/src/commands/migrate.yml
@@ -1,0 +1,24 @@
+description: Apply conformance-based migration to a consumer's .circleci/ directory  Reads conformance rules from a JSON file (produced by `diff`) and applies them to the consumer's CI config. Reports planned changes before applying.
+parameters:
+  ci_dir:
+    type: string
+    description: Path to the consumer's .circleci/ directory
+    default: .circleci
+  orb:
+    type: string
+    description: 'The orb alias as used in the consumer''s orbs: section (e.g. "toolkit")'
+  rules:
+    type: string
+    description: Path to the conformance rules JSON file (produced by `diff`)
+  dry_run:
+    type: boolean
+    description: Show planned changes without modifying files
+steps:
+- run:
+    name: migrate
+    command: |-
+      gen-orb-mcp migrate \
+        <<# parameters.ci_dir >>--ci-dir "<< parameters.ci_dir >>"<</ parameters.ci_dir >> \
+        --orb "<< parameters.orb >>" \
+        --rules "<< parameters.rules >>" \
+        <<# parameters.dry_run >>--dry-run<</ parameters.dry_run >>

--- a/orb/src/commands/prime.yml
+++ b/orb/src/commands/prime.yml
@@ -1,0 +1,51 @@
+description: 'Populate prior-versions/ and migrations/ from git history  Discovers version tags in a sliding window (default: last 6 months), checks out each version, saves a snapshot to `prior-versions/<version>.yml`, and computes conformance-rule diffs to `migrations/<version>.json`. Removes files for versions outside the window to keep binary size bounded. Idempotent.'
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML entry point
+    default: src/@orb.yml
+  git_repo:
+    type: string
+    description: 'Path to the git repository root (default: walk up from orb-path to .git)'
+  tag_prefix:
+    type: string
+    description: Git tag prefix (e.g. "v" matches tags like "v4.1.0")
+    default: v
+  earliest_version:
+    type: string
+    description: Fixed earliest version anchor (e.g. "4.1.0"); conflicts with --since
+  since:
+    type: string
+    description: 'Rolling window duration (e.g. "6 months", "1 year"); default: "6 months"'
+  prior_versions_dir:
+    type: string
+    description: Directory to write prior-version snapshots
+    default: prior-versions
+  migrations_dir:
+    type: string
+    description: Directory to write migration rule JSON files
+    default: migrations
+  ephemeral:
+    type: boolean
+    description: /` and print PRIME_PV_DIR/PRIME_MIG_DIR to stdout
+  rename_map:
+    type: string
+    description: 'Override git rename detection for a specific job (repeatable). Format: `OLD=NEW`, e.g. `--rename-map common_tests_rolling=common_tests`. Manual entries take precedence over git-detected hints for matching old names.  Use this when commits cannot be restructured to follow the two-commit rename rule'
+  dry_run:
+    type: boolean
+    description: Describe actions without writing any files
+steps:
+- run:
+    name: prime
+    command: |-
+      gen-orb-mcp prime \
+        <<# parameters.orb_path >>--orb-path "<< parameters.orb_path >>"<</ parameters.orb_path >> \
+        --git-repo "<< parameters.git_repo >>" \
+        <<# parameters.tag_prefix >>--tag-prefix "<< parameters.tag_prefix >>"<</ parameters.tag_prefix >> \
+        --earliest-version "<< parameters.earliest_version >>" \
+        --since "<< parameters.since >>" \
+        <<# parameters.prior_versions_dir >>--prior-versions-dir "<< parameters.prior_versions_dir >>"<</ parameters.prior_versions_dir >> \
+        <<# parameters.migrations_dir >>--migrations-dir "<< parameters.migrations_dir >>"<</ parameters.migrations_dir >> \
+        <<# parameters.ephemeral >>--ephemeral<</ parameters.ephemeral >> \
+        --rename-map "<< parameters.rename_map >>" \
+        <<# parameters.dry_run >>--dry-run<</ parameters.dry_run >>

--- a/orb/src/commands/validate.yml
+++ b/orb/src/commands/validate.yml
@@ -1,0 +1,11 @@
+description: Validate an orb definition without generating
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML file
+steps:
+- run:
+    name: validate
+    command: |-
+      gen-orb-mcp validate \
+        --orb-path "<< parameters.orb_path >>"

--- a/orb/src/executors/default.yml
+++ b/orb/src/executors/default.yml
@@ -1,0 +1,8 @@
+description: Execution environment with gen-orb-mcp pre-installed.
+docker:
+- image: jerusdp/gen-orb-mcp:<< parameters.tag >>
+parameters:
+  tag:
+    type: string
+    description: Docker image tag.
+    default: latest

--- a/orb/src/jobs/diff.yml
+++ b/orb/src/jobs/diff.yml
@@ -1,0 +1,22 @@
+description: Run diff command in a dedicated job.
+executor: default
+parameters:
+  current:
+    type: string
+    description: Path to the current orb YAML (the new version)
+  previous:
+    type: string
+    description: Path to the previous orb YAML (the old version to diff against)
+  since_version:
+    type: string
+    description: The version string to embed in emitted rules (e.g. "5.0.0")
+  output:
+    type: string
+    description: 'Optional output file for the JSON rules (default: stdout)'
+steps:
+- checkout
+- diff:
+    current: << parameters.current >>
+    previous: << parameters.previous >>
+    since_version: << parameters.since_version >>
+    output: << parameters.output >>

--- a/orb/src/jobs/generate.yml
+++ b/orb/src/jobs/generate.yml
@@ -1,0 +1,44 @@
+description: Run generate command in a dedicated job.
+executor: default
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML file (e.g., src/@orb.yml)
+  output:
+    type: string
+    description: Output directory for generated server
+    default: ./dist
+  format:
+    type: enum
+    description: Output format
+    default: source
+    enum:
+    - binary
+    - source
+  name:
+    type: string
+    description: Name for the generated orb server (defaults to filename)
+  force:
+    type: boolean
+    description: Required for non-interactive CI environments when output exists.
+  migrations:
+    type: string
+    description: Directory containing conformance rule JSON files to embed in the server  All *.json files in this directory are merged and embedded as migration tooling in the generated server. When provided, the server gains plan_migration and apply_migration MCP Tools in addition to Resources.
+  prior_versions:
+    type: string
+    description: .yml` (e.g., `4.7.1.yml`). The generated server will expose version-specific resources for each prior version alongside the current version.
+  tag_prefix:
+    type: string
+    description: Tag prefix used to discover the orb version from git tags  The git repository is derived automatically from --orb-path. Defaults to "v" (matches tags like v6.0.0).
+    default: v
+steps:
+- checkout
+- generate:
+    orb_path: << parameters.orb_path >>
+    output: << parameters.output >>
+    format: << parameters.format >>
+    name: << parameters.name >>
+    force: << parameters.force >>
+    migrations: << parameters.migrations >>
+    prior_versions: << parameters.prior_versions >>
+    tag_prefix: << parameters.tag_prefix >>

--- a/orb/src/jobs/migrate.yml
+++ b/orb/src/jobs/migrate.yml
@@ -1,0 +1,23 @@
+description: Run migrate command in a dedicated job.
+executor: default
+parameters:
+  ci_dir:
+    type: string
+    description: Path to the consumer's .circleci/ directory
+    default: .circleci
+  orb:
+    type: string
+    description: 'The orb alias as used in the consumer''s orbs: section (e.g. "toolkit")'
+  rules:
+    type: string
+    description: Path to the conformance rules JSON file (produced by `diff`)
+  dry_run:
+    type: boolean
+    description: Show planned changes without modifying files
+steps:
+- checkout
+- migrate:
+    ci_dir: << parameters.ci_dir >>
+    orb: << parameters.orb >>
+    rules: << parameters.rules >>
+    dry_run: << parameters.dry_run >>

--- a/orb/src/jobs/prime.yml
+++ b/orb/src/jobs/prime.yml
@@ -1,0 +1,50 @@
+description: Run prime command in a dedicated job.
+executor: default
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML entry point
+    default: src/@orb.yml
+  git_repo:
+    type: string
+    description: 'Path to the git repository root (default: walk up from orb-path to .git)'
+  tag_prefix:
+    type: string
+    description: Git tag prefix (e.g. "v" matches tags like "v4.1.0")
+    default: v
+  earliest_version:
+    type: string
+    description: Fixed earliest version anchor (e.g. "4.1.0"); conflicts with --since
+  since:
+    type: string
+    description: 'Rolling window duration (e.g. "6 months", "1 year"); default: "6 months"'
+  prior_versions_dir:
+    type: string
+    description: Directory to write prior-version snapshots
+    default: prior-versions
+  migrations_dir:
+    type: string
+    description: Directory to write migration rule JSON files
+    default: migrations
+  ephemeral:
+    type: boolean
+    description: /` and print PRIME_PV_DIR/PRIME_MIG_DIR to stdout
+  rename_map:
+    type: string
+    description: 'Override git rename detection for a specific job (repeatable). Format: `OLD=NEW`, e.g. `--rename-map common_tests_rolling=common_tests`. Manual entries take precedence over git-detected hints for matching old names.  Use this when commits cannot be restructured to follow the two-commit rename rule'
+  dry_run:
+    type: boolean
+    description: Describe actions without writing any files
+steps:
+- checkout
+- prime:
+    orb_path: << parameters.orb_path >>
+    git_repo: << parameters.git_repo >>
+    tag_prefix: << parameters.tag_prefix >>
+    earliest_version: << parameters.earliest_version >>
+    since: << parameters.since >>
+    prior_versions_dir: << parameters.prior_versions_dir >>
+    migrations_dir: << parameters.migrations_dir >>
+    ephemeral: << parameters.ephemeral >>
+    rename_map: << parameters.rename_map >>
+    dry_run: << parameters.dry_run >>

--- a/orb/src/jobs/validate.yml
+++ b/orb/src/jobs/validate.yml
@@ -1,0 +1,10 @@
+description: Run validate command in a dedicated job.
+executor: default
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML file
+steps:
+- checkout
+- validate:
+    orb_path: << parameters.orb_path >>


### PR DESCRIPTION
## Summary

- Adds `orb-tools/pack`, `orb-tools/review`, and `regenerate-orb` jobs to the validation workflow (runs after `common-tests`)
- Adds `orb-tools/pack`, `build-container`, and `orb-tools/publish` steps to the release workflow (runs after `release-gen-orb-mcp`)
- Adds generated orb source (`orb/src/`) with commands, jobs, and executor for all 5 gen-orb-mcp subcommands (generate, validate, diff, migrate, prime)

## Test plan

- [ ] Verify CI pipeline runs `regenerate-orb` and then `orb-tools/pack` + `orb-tools/review`
- [ ] Verify orb packs without errors via `circleci orb pack orb/src`
- [ ] Verify release workflow correctly publishes orb via `orb-tools/publish` after container build

🤖 Generated with [Claude Code](https://claude.com/claude-code)