### PR TITLE
feat: wire orb generation via gen-circleci-orb init

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,36 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
 
+  orb-tools: circleci/orb-tools@12.3.3
+jobs:
+  build-binary:
+    docker:
+      - image: rust:latest
+    steps:
+      - checkout
+      - run:
+          name: Build binary
+          command: cargo build --release
+      - persist_to_workspace:
+          root: target/release
+          paths: [gen-orb-mcp]
+  regenerate-orb:
+    docker:
+      - image: jerusdp/gen-circleci-orb:latest
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/bin
+      - run:
+          name: Regenerate orb source
+          command: |
+            export PATH="/tmp/bin:$PATH"
+            gen-circleci-orb generate \
+              --binary gen-orb-mcp \
+              --namespace jerus-org \
+              --orb-dir orb
+
+
 workflows:
   validation:
     jobs:
@@ -78,3 +108,15 @@ workflows:
                 - /pull\/[0-9]+/
                 - main
 
+      - build-binary:
+          requires: [toolkit/common_tests]
+      - regenerate-orb:
+          requires: [build-binary]
+      - orb-tools/pack:
+          name: pack-orb
+          source_dir: orb/src
+          requires: [regenerate-orb]
+      - orb-tools/review:
+          name: review-orb
+          source_dir: orb/src
+          requires: [pack-orb]

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -13,6 +13,8 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
 
+  orb-tools: circleci/orb-tools@12.3.3
+  docker: circleci/docker@3.2.0
 jobs:
   tools:
     executor: toolkit/rust_env_rolling
@@ -26,6 +28,46 @@ jobs:
             cargo release --version
             rsign --version
 
+  build-binary-release:
+    docker:
+      - image: rust:latest
+    steps:
+      - checkout
+      - run:
+          name: Build release binary
+          command: cargo build --release -p gen-orb-mcp
+      - persist_to_workspace:
+          root: target/release
+          paths: [gen-orb-mcp]
+  ensure-orb-registered:
+    executor: orb-tools/default
+    steps:
+      - run:
+          name: Ensure orb is registered
+          command: |
+            circleci setup --token "${CIRCLE_TOKEN}" --host https://circleci.com --no-prompt
+            circleci orb info jerus-org/gen-orb-mcp > /dev/null 2>&1 || \
+              circleci orb create jerus-org/gen-orb-mcp --no-prompt
+  build-container:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: /tmp/release-versions
+      - attach_workspace:
+          at: /tmp/bin
+      - run:
+          name: Build and push Docker image
+          command: |
+            source /tmp/release-versions/versions.env
+            VERSION=${CRATE_VERSION_GEN_ORB_MCP}
+            cp /tmp/bin/gen-orb-mcp orb/gen-orb-mcp
+            docker build -t jerusdp/gen-orb-mcp:${VERSION} -t jerusdp/gen-orb-mcp:latest orb
+            echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+            docker push jerusdp/gen-orb-mcp:${VERSION}
+            docker push jerusdp/gen-orb-mcp:latest
 workflows:
   release:
     jobs:
@@ -44,7 +86,7 @@ workflows:
 
       - toolkit/release_crate:
           name: release-gen-orb-mcp
-          requires: [approve-release]
+          requires: [publish-orb-jerus-org]
           package: gen-orb-mcp
           crate_tag_prefix: gen-orb-mcp-v
           build_binary: true
@@ -60,3 +102,30 @@ workflows:
             - release
             - bot-check
             - pcu-app
+      - build-binary-release:
+          requires: [approve-release]
+      - orb-tools/pack:
+          name: pack-orb-release
+          source_dir: orb/src
+          requires: [approve-release]
+      - build-container:
+          requires: [build-binary-release]
+          context: [docker-credentials]
+      - ensure-orb-registered:
+          requires: [approve-release]
+          context: [orb-publishing]
+      - orb-tools/publish:
+          name: publish-orb-jerus-org
+          pre-steps:
+            - attach_workspace:
+                at: /tmp/release-versions
+            - run:
+                name: Export orb version as CIRCLE_TAG
+                command: |
+                  source /tmp/release-versions/versions.env
+                  echo "export CIRCLE_TAG=v${CRATE_VERSION_GEN_ORB_MCP}" >> "$BASH_ENV"
+          orb_name: jerus-org/gen-orb-mcp
+          pub_type: production
+          vcs_type: github
+          requires: [build-container, pack-orb-release, ensure-orb-registered]
+          context: [orb-publishing]

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ tarpaulin-report.html
 # OS
 .DS_Store
 Thumbs.db
+
+# Binary copied into orb build context during release; not for version control
+/orb/gen-orb-mcp

--- a/orb/Dockerfile
+++ b/orb/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:12-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl git \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -L --proto '=https' --tlsv1.2 -sSf \
+       https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash \
+    && cargo-binstall --no-confirm gen-orb-mcp \
+    && rm -rf /root/.cargo/registry /root/.cargo/git

--- a/orb/src/@orb.yml
+++ b/orb/src/@orb.yml
@@ -1,0 +1,3 @@
+version: 2.1
+description: >
+  Generate MCP servers from CircleCI orb definitions

--- a/orb/src/commands/diff.yml
+++ b/orb/src/commands/diff.yml
@@ -1,0 +1,19 @@
+description: Compute conformance rules by diffing two orb versions  Compares the current orb against a previous version (read from a file) and emits a JSON array of ConformanceRule values. These rules can be passed to `generate --migrations` to embed migration tooling in the generated MCP server.
+parameters:
+  current:
+    type: string
+    description: Path to the current orb YAML (the new version)
+  previous:
+    type: string
+    description: Path to the previous orb YAML (the old version to diff against)
+  since_version:
+    type: string
+    description: The version string to embed in emitted rules (e.g. "5.0.0")
+  output:
+    type: string
+    description: 'Optional output file for the JSON rules (default: stdout)'
+    default: ''
+steps:
+- run:
+    name: diff
+    command: <<include(scripts/diff.sh)>>

--- a/orb/src/commands/generate.yml
+++ b/orb/src/commands/generate.yml
@@ -1,0 +1,44 @@
+description: Generate an MCP server from an orb definition
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML file (e.g., src/@orb.yml)
+  output:
+    type: string
+    description: Output directory for generated server
+    default: ./dist
+  format:
+    type: enum
+    description: Output format
+    default: source
+    enum:
+    - binary
+    - source
+  name:
+    type: string
+    description: Name for the generated orb server (defaults to filename)
+    default: ''
+  version:
+    type: string
+    description: Version for the generated MCP server crate (e.g., "1.0.0")  Required when regenerating an existing output directory. For CI workflows, this should match the orb release version.
+    default: ''
+  force:
+    type: boolean
+    description: Overwrite existing files without confirmation  Required for non-interactive CI environments when output exists.
+    default: false
+  migrations:
+    type: string
+    description: Directory containing conformance rule JSON files to embed in the server  All *.json files in this directory are merged and embedded as migration tooling in the generated server. When provided, the server gains plan_migration and apply_migration MCP Tools in addition to Resources.
+    default: ''
+  prior_versions:
+    type: string
+    description: Directory of prior orb version YAML snapshots to embed in the server  Each file should be named `<version>.yml` (e.g., `4.7.1.yml`). The generated server will expose version-specific resources for each prior version alongside the current version.
+    default: ''
+  tag_prefix:
+    type: string
+    description: Tag prefix used to discover the orb version from git tags  The git repository is derived automatically from --orb-path. Defaults to "v" (matches tags like v6.0.0).
+    default: v
+steps:
+- run:
+    name: generate
+    command: <<include(scripts/generate.sh)>>

--- a/orb/src/commands/migrate.yml
+++ b/orb/src/commands/migrate.yml
@@ -1,0 +1,20 @@
+description: Apply conformance-based migration to a consumer's .circleci/ directory  Reads conformance rules from a JSON file (produced by `diff`) and applies them to the consumer's CI config. Reports planned changes before applying.
+parameters:
+  ci_dir:
+    type: string
+    description: Path to the consumer's .circleci/ directory
+    default: .circleci
+  orb:
+    type: string
+    description: 'The orb alias as used in the consumer''s orbs: section (e.g. "toolkit")'
+  rules:
+    type: string
+    description: Path to the conformance rules JSON file (produced by `diff`)
+  dry_run:
+    type: boolean
+    description: Show planned changes without modifying files
+    default: false
+steps:
+- run:
+    name: migrate
+    command: <<include(scripts/migrate.sh)>>

--- a/orb/src/commands/prime.yml
+++ b/orb/src/commands/prime.yml
@@ -1,0 +1,46 @@
+description: 'Populate prior-versions/ and migrations/ from git history  Discovers version tags in a sliding window (default: last 6 months), checks out each version, saves a snapshot to `prior-versions/<version>.yml`, and computes conformance-rule diffs to `migrations/<version>.json`. Removes files for versions outside the window to keep binary size bounded. Idempotent.'
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML entry point
+    default: src/@orb.yml
+  git_repo:
+    type: string
+    description: 'Path to the git repository root (default: walk up from orb-path to .git)'
+    default: ''
+  tag_prefix:
+    type: string
+    description: Git tag prefix (e.g. "v" matches tags like "v4.1.0")
+    default: v
+  earliest_version:
+    type: string
+    description: Fixed earliest version anchor (e.g. "4.1.0"); conflicts with --since
+    default: ''
+  since:
+    type: string
+    description: 'Rolling window duration (e.g. "6 months", "1 year"); default: "6 months"'
+    default: ''
+  prior_versions_dir:
+    type: string
+    description: Directory to write prior-version snapshots
+    default: prior-versions
+  migrations_dir:
+    type: string
+    description: Directory to write migration rule JSON files
+    default: migrations
+  ephemeral:
+    type: boolean
+    description: Write to `/tmp/gen-orb-mcp-prime-<pid>/` and print PRIME_PV_DIR/PRIME_MIG_DIR to stdout
+    default: false
+  rename_map:
+    type: string
+    description: '<OLD=NEW> Override git rename detection for a specific job (repeatable). Format: `OLD=NEW`, e.g. `--rename-map common_tests_rolling=common_tests`. Manual entries take precedence over git-detected hints for matching old names.  Use this when commits cannot be restructured to follow the two-commit rename rule'
+    default: ''
+  dry_run:
+    type: boolean
+    description: Describe actions without writing any files
+    default: false
+steps:
+- run:
+    name: prime
+    command: <<include(scripts/prime.sh)>>

--- a/orb/src/commands/validate.yml
+++ b/orb/src/commands/validate.yml
@@ -1,0 +1,9 @@
+description: Validate an orb definition without generating
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML file
+steps:
+- run:
+    name: validate
+    command: <<include(scripts/validate.sh)>>

--- a/orb/src/examples/example.yml
+++ b/orb/src/examples/example.yml
@@ -1,0 +1,10 @@
+description: >
+  Example usage of the gen-orb-mcp orb.
+usage:
+  version: 2.1
+  orbs:
+    gen-orb-mcp: jerus-org/gen-orb-mcp@1.0
+  workflows:
+    use-my-orb:
+      jobs:
+        - gen-orb-mcp/generate

--- a/orb/src/executors/default.yml
+++ b/orb/src/executors/default.yml
@@ -1,0 +1,8 @@
+description: Execution environment with gen-orb-mcp pre-installed.
+docker:
+- image: jerusdp/gen-orb-mcp:<< parameters.tag >>
+parameters:
+  tag:
+    type: string
+    description: Docker image tag.
+    default: latest

--- a/orb/src/jobs/diff.yml
+++ b/orb/src/jobs/diff.yml
@@ -1,0 +1,23 @@
+description: Run diff command in a dedicated job.
+executor: default
+parameters:
+  current:
+    type: string
+    description: Path to the current orb YAML (the new version)
+  previous:
+    type: string
+    description: Path to the previous orb YAML (the old version to diff against)
+  since_version:
+    type: string
+    description: The version string to embed in emitted rules (e.g. "5.0.0")
+  output:
+    type: string
+    description: 'Optional output file for the JSON rules (default: stdout)'
+    default: ''
+steps:
+- checkout
+- diff:
+    current: << parameters.current >>
+    previous: << parameters.previous >>
+    since_version: << parameters.since_version >>
+    output: << parameters.output >>

--- a/orb/src/jobs/generate.yml
+++ b/orb/src/jobs/generate.yml
@@ -1,0 +1,48 @@
+description: Run generate command in a dedicated job.
+executor: default
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML file (e.g., src/@orb.yml)
+  output:
+    type: string
+    description: Output directory for generated server
+    default: ./dist
+  format:
+    type: enum
+    description: Output format
+    default: source
+    enum:
+    - binary
+    - source
+  version:
+    type: string
+    description: Version for the generated MCP server crate (e.g., "1.0.0")  Required when regenerating an existing output directory. For CI workflows, this should match the orb release version.
+    default: ''
+  force:
+    type: boolean
+    description: Overwrite existing files without confirmation  Required for non-interactive CI environments when output exists.
+    default: false
+  migrations:
+    type: string
+    description: Directory containing conformance rule JSON files to embed in the server  All *.json files in this directory are merged and embedded as migration tooling in the generated server. When provided, the server gains plan_migration and apply_migration MCP Tools in addition to Resources.
+    default: ''
+  prior_versions:
+    type: string
+    description: Directory of prior orb version YAML snapshots to embed in the server  Each file should be named `<version>.yml` (e.g., `4.7.1.yml`). The generated server will expose version-specific resources for each prior version alongside the current version.
+    default: ''
+  tag_prefix:
+    type: string
+    description: Tag prefix used to discover the orb version from git tags  The git repository is derived automatically from --orb-path. Defaults to "v" (matches tags like v6.0.0).
+    default: v
+steps:
+- checkout
+- generate:
+    orb_path: << parameters.orb_path >>
+    output: << parameters.output >>
+    format: << parameters.format >>
+    version: << parameters.version >>
+    force: << parameters.force >>
+    migrations: << parameters.migrations >>
+    prior_versions: << parameters.prior_versions >>
+    tag_prefix: << parameters.tag_prefix >>

--- a/orb/src/jobs/migrate.yml
+++ b/orb/src/jobs/migrate.yml
@@ -1,0 +1,24 @@
+description: Run migrate command in a dedicated job.
+executor: default
+parameters:
+  ci_dir:
+    type: string
+    description: Path to the consumer's .circleci/ directory
+    default: .circleci
+  orb:
+    type: string
+    description: 'The orb alias as used in the consumer''s orbs: section (e.g. "toolkit")'
+  rules:
+    type: string
+    description: Path to the conformance rules JSON file (produced by `diff`)
+  dry_run:
+    type: boolean
+    description: Show planned changes without modifying files
+    default: false
+steps:
+- checkout
+- migrate:
+    ci_dir: << parameters.ci_dir >>
+    orb: << parameters.orb >>
+    rules: << parameters.rules >>
+    dry_run: << parameters.dry_run >>

--- a/orb/src/jobs/prime.yml
+++ b/orb/src/jobs/prime.yml
@@ -1,0 +1,56 @@
+description: Run prime command in a dedicated job.
+executor: default
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML entry point
+    default: src/@orb.yml
+  git_repo:
+    type: string
+    description: 'Path to the git repository root (default: walk up from orb-path to .git)'
+    default: ''
+  tag_prefix:
+    type: string
+    description: Git tag prefix (e.g. "v" matches tags like "v4.1.0")
+    default: v
+  earliest_version:
+    type: string
+    description: Fixed earliest version anchor (e.g. "4.1.0"); conflicts with --since
+    default: ''
+  since:
+    type: string
+    description: 'Rolling window duration (e.g. "6 months", "1 year"); default: "6 months"'
+    default: ''
+  prior_versions_dir:
+    type: string
+    description: Directory to write prior-version snapshots
+    default: prior-versions
+  migrations_dir:
+    type: string
+    description: Directory to write migration rule JSON files
+    default: migrations
+  ephemeral:
+    type: boolean
+    description: Write to `/tmp/gen-orb-mcp-prime-<pid>/` and print PRIME_PV_DIR/PRIME_MIG_DIR to stdout
+    default: false
+  rename_map:
+    type: string
+    description: '<OLD=NEW> Override git rename detection for a specific job (repeatable). Format: `OLD=NEW`, e.g. `--rename-map common_tests_rolling=common_tests`. Manual entries take precedence over git-detected hints for matching old names.  Use this when commits cannot be restructured to follow the two-commit rename rule'
+    default: ''
+  dry_run:
+    type: boolean
+    description: Describe actions without writing any files
+    default: false
+steps:
+- checkout
+- prime:
+    orb_path: << parameters.orb_path >>
+    git_repo: << parameters.git_repo >>
+    tag_prefix: << parameters.tag_prefix >>
+    earliest_version: << parameters.earliest_version >>
+    since: << parameters.since >>
+    prior_versions_dir: << parameters.prior_versions_dir >>
+    migrations_dir: << parameters.migrations_dir >>
+    ephemeral: << parameters.ephemeral >>
+    rename_map: << parameters.rename_map >>
+    dry_run: << parameters.dry_run >>

--- a/orb/src/jobs/validate.yml
+++ b/orb/src/jobs/validate.yml
@@ -1,0 +1,10 @@
+description: Run validate command in a dedicated job.
+executor: default
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML file
+steps:
+- checkout
+- validate:
+    orb_path: << parameters.orb_path >>

--- a/orb/src/scripts/diff.sh
+++ b/orb/src/scripts/diff.sh
@@ -1,0 +1,5 @@
+gen-orb-mcp diff \
+  --current "<< parameters.current >>" \
+  --previous "<< parameters.previous >>" \
+  --since-version "<< parameters.since_version >>" \
+  <<# parameters.output >>--output "<< parameters.output >>"<</ parameters.output >>

--- a/orb/src/scripts/generate.sh
+++ b/orb/src/scripts/generate.sh
@@ -1,0 +1,10 @@
+gen-orb-mcp generate \
+  --orb-path "<< parameters.orb_path >>" \
+  <<# parameters.output >>--output "<< parameters.output >>"<</ parameters.output >> \
+  <<# parameters.format >>--format "<< parameters.format >>"<</ parameters.format >> \
+  <<# parameters.name >>--name "<< parameters.name >>"<</ parameters.name >> \
+  <<# parameters.version >>--version "<< parameters.version >>"<</ parameters.version >> \
+  <<# parameters.force >>--force<</ parameters.force >> \
+  <<# parameters.migrations >>--migrations "<< parameters.migrations >>"<</ parameters.migrations >> \
+  <<# parameters.prior_versions >>--prior-versions "<< parameters.prior_versions >>"<</ parameters.prior_versions >> \
+  <<# parameters.tag_prefix >>--tag-prefix "<< parameters.tag_prefix >>"<</ parameters.tag_prefix >>

--- a/orb/src/scripts/migrate.sh
+++ b/orb/src/scripts/migrate.sh
@@ -1,0 +1,5 @@
+gen-orb-mcp migrate \
+  <<# parameters.ci_dir >>--ci-dir "<< parameters.ci_dir >>"<</ parameters.ci_dir >> \
+  --orb "<< parameters.orb >>" \
+  --rules "<< parameters.rules >>" \
+  <<# parameters.dry_run >>--dry-run<</ parameters.dry_run >>

--- a/orb/src/scripts/prime.sh
+++ b/orb/src/scripts/prime.sh
@@ -1,0 +1,11 @@
+gen-orb-mcp prime \
+  <<# parameters.orb_path >>--orb-path "<< parameters.orb_path >>"<</ parameters.orb_path >> \
+  <<# parameters.git_repo >>--git-repo "<< parameters.git_repo >>"<</ parameters.git_repo >> \
+  <<# parameters.tag_prefix >>--tag-prefix "<< parameters.tag_prefix >>"<</ parameters.tag_prefix >> \
+  <<# parameters.earliest_version >>--earliest-version "<< parameters.earliest_version >>"<</ parameters.earliest_version >> \
+  <<# parameters.since >>--since "<< parameters.since >>"<</ parameters.since >> \
+  <<# parameters.prior_versions_dir >>--prior-versions-dir "<< parameters.prior_versions_dir >>"<</ parameters.prior_versions_dir >> \
+  <<# parameters.migrations_dir >>--migrations-dir "<< parameters.migrations_dir >>"<</ parameters.migrations_dir >> \
+  <<# parameters.ephemeral >>--ephemeral<</ parameters.ephemeral >> \
+  <<# parameters.rename_map >>--rename-map "<< parameters.rename_map >>"<</ parameters.rename_map >> \
+  <<# parameters.dry_run >>--dry-run<</ parameters.dry_run >>

--- a/orb/src/scripts/validate.sh
+++ b/orb/src/scripts/validate.sh
@@ -1,0 +1,2 @@
+gen-orb-mcp validate \
+  --orb-path "<< parameters.orb_path >>"


### PR DESCRIPTION
## Summary

- Runs `gen-circleci-orb init` (v0.0.9) to wire the full orb generation and release pipeline from a clean baseline
- Validates that the tool generates what was previously handcrafted, with one manual fix (release ordering)

### config.yml changes (generated)
- Adds `orb-tools: circleci/orb-tools@12.3.3` orb
- Adds `build-binary` job (`rust:latest`) — compiles `gen-orb-mcp` and persists to workspace
- Adds `regenerate-orb` job (`jerusdp/gen-circleci-orb:latest`) — attaches workspace binary and re-generates orb source on every push
- Adds validation workflow steps: `build-binary → regenerate-orb → pack-orb → review-orb`

### release.yml changes (generated + one manual fix)
- Adds `docker: circleci/docker@3.2.0` and `orb-tools: circleci/orb-tools@12.3.3` orbs
- Adds `build-binary-release` job — compiles release binary and persists to workspace
- Adds `ensure-orb-registered` job — configures CLI with `CIRCLE_TOKEN` and idempotently creates the orb if not yet registered
- Adds `build-container` job — uses versions.env + workspace binary to build and push `jerusdp/gen-orb-mcp:VERSION` and `:latest`
- Adds release workflow steps: `build-binary-release → build-container`, `pack-orb-release`, `ensure-orb-registered → orb-tools/publish`
- **Manual fix**: `toolkit/release_crate` now `requires: [publish-orb-jerus-org]` so the orb is published before crates.io (same ordering as gen-circleci-orb)

### orb/ (generated)
- 5 commands, 5 jobs, 5 scripts, 1 executor, `@orb.yml`, `Dockerfile`
- Generated from `gen-orb-mcp 0.1.9 --help` output

### .gitignore
- Adds `/orb/gen-orb-mcp` — the binary copied into the container build context during release

## Test plan

- [ ] Validation pipeline runs: `build-binary → regenerate-orb → pack-orb → review-orb`
- [ ] Release pipeline runs end-to-end after approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)