### PR TITLE
test: add compilation test for generated MCP server

### DIFF
--- a/crates/gen-orb-mcp/templates/lib.rs.hbs
+++ b/crates/gen-orb-mcp/templates/lib.rs.hbs
@@ -27,12 +27,10 @@
 use rmcp::{
     ServerHandler,
     model::{
-        AnnotateAble, ErrorData as McpError, Implementation, ListResourcesResult,
-        PaginatedRequestParams, ProtocolVersion, RawResource, ReadResourceRequestParams,
-        ReadResourceResult, ResourceContents, ServerCapabilities, ServerInfo,
-{{#if has_tools}}
-        CallToolRequestParams, CallToolResult, Content, ListToolsResult, Tool,
-{{/if}}
+        AnnotateAble, CallToolRequestParams, CallToolResult, Content, ErrorData as McpError,
+        Implementation, ListResourcesResult, ListToolsResult, PaginatedRequestParams,
+        ProtocolVersion, RawResource, ReadResourceRequestParams, ReadResourceResult,
+        ResourceContents, ServerCapabilities, ServerInfo, Tool,
     },
     service::RequestContext,
     RoleServer,
@@ -89,9 +87,7 @@ impl ServerHandler for OrbServer {
             protocol_version: ProtocolVersion::LATEST,
             capabilities: ServerCapabilities::builder()
                 .enable_resources()
-{{#if has_tools}}
                 .enable_tools()
-{{/if}}
                 .build(),
             server_info: Implementation {
                 name: "{{orb_name}}-mcp".into(),
@@ -203,7 +199,11 @@ impl ServerHandler for OrbServer {
         _ctx: RequestContext<RoleServer>,
     ) -> impl std::future::Future<Output = Result<ListToolsResult, McpError>> + Send + '_ {
         async move {
-            let mut tools = vec![
+{{#if has_tools}}
+            let mut tools: Vec<Tool> = vec![
+{{else}}
+            let tools: Vec<Tool> = vec![
+{{/if}}
                 Tool {
                     name: "get_version".into(),
                     title: None,
@@ -306,7 +306,11 @@ impl ServerHandler for OrbServer {
         _ctx: RequestContext<RoleServer>,
     ) -> impl std::future::Future<Output = Result<CallToolResult, McpError>> + Send + '_ {
         async move {
+{{#if has_tools}}
             let args = request.arguments.unwrap_or_default();
+{{else}}
+            let _ = request.arguments;
+{{/if}}
             match request.name.as_ref() {
                 "get_version" => Ok(CallToolResult::success(vec![Content::text(
                     serde_json::json!({

--- a/crates/gen-orb-mcp/templates/lib.rs.hbs
+++ b/crates/gen-orb-mcp/templates/lib.rs.hbs
@@ -199,11 +199,7 @@ impl ServerHandler for OrbServer {
         _ctx: RequestContext<RoleServer>,
     ) -> impl std::future::Future<Output = Result<ListToolsResult, McpError>> + Send + '_ {
         async move {
-{{#if has_tools}}
             let mut tools: Vec<Tool> = vec![
-{{else}}
-            let tools: Vec<Tool> = vec![
-{{/if}}
                 Tool {
                     name: "get_version".into(),
                     title: None,

--- a/crates/gen-orb-mcp/tests/generated_compilation.rs
+++ b/crates/gen-orb-mcp/tests/generated_compilation.rs
@@ -1,0 +1,92 @@
+/// Integration test: generated MCP server source compiles with cargo build.
+///
+/// This test exercises the full generation pipeline — template rendering plus
+/// dependency resolution — to catch rmcp API or feature-flag mismatches that
+/// content-only string assertions cannot detect.
+use std::{collections::HashMap, process::Command};
+
+use gen_orb_mcp::{
+    generator::CodeGenerator,
+    parser::{Command as OrbCommand, Job, OrbDefinition, Parameter, ParameterType},
+};
+use tempfile::TempDir;
+
+fn fixture_orb() -> OrbDefinition {
+    let mut orb = OrbDefinition {
+        version: "2.1".to_string(),
+        description: Some(
+            "Fixture orb for compilation tests — exercises commands, jobs, and tools path"
+                .to_string(),
+        ),
+        ..Default::default()
+    };
+
+    // Command with a string parameter (exercises has_tools path in template)
+    let mut cmd_params = HashMap::new();
+    cmd_params.insert(
+        "message".to_string(),
+        Parameter {
+            param_type: ParameterType::String,
+            description: Some("Message to print".to_string()),
+            default: Some(serde_yaml::Value::String("hello".to_string())),
+            enum_values: None,
+        },
+    );
+    orb.commands.insert(
+        "print".to_string(),
+        OrbCommand {
+            description: Some("Print a message".to_string()),
+            parameters: cmd_params,
+            steps: vec![],
+        },
+    );
+
+    // Job (exercises resource generation)
+    let mut job_params = HashMap::new();
+    job_params.insert(
+        "tag".to_string(),
+        Parameter {
+            param_type: ParameterType::String,
+            description: Some("Docker image tag".to_string()),
+            default: Some(serde_yaml::Value::String("latest".to_string())),
+            enum_values: None,
+        },
+    );
+    orb.jobs.insert(
+        "run-print".to_string(),
+        Job {
+            description: Some("Run the print command".to_string()),
+            parameters: job_params,
+            steps: vec![],
+            executor: None,
+            config: Default::default(),
+            parallelism: None,
+            circleci_ip_ranges: None,
+        },
+    );
+
+    orb
+}
+
+#[test]
+fn generated_server_compiles() {
+    let generator = CodeGenerator::new().expect("CodeGenerator::new");
+    let orb = fixture_orb();
+    let server = generator
+        .generate(&orb, "fixture-orb", "1.0.0")
+        .expect("generate");
+
+    let tmp = TempDir::new().expect("TempDir::new");
+    server.write_to(tmp.path()).expect("write_to");
+
+    let status = Command::new("cargo")
+        .args(["build", "--color", "never"])
+        .current_dir(tmp.path())
+        .status()
+        .expect("failed to run cargo build");
+
+    assert!(
+        status.success(),
+        "generated MCP server did not compile — check template rmcp version and import paths"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `tests/generated_compilation.rs` — an integration test that generates a server from a fixture orb, writes it to a temp dir, and runs `cargo build` to verify the generated Rust code actually compiles. Catches rmcp API/version mismatches that content-only string assertions cannot detect.
- Fix the bug exposed by this test: `list_tools` and `call_tool` (including the always-present `get_version` tool) were moved outside the `{{#if has_tools}}` guard in a prior commit, but the imports for `CallToolRequestParams, CallToolResult, Content, ListToolsResult, Tool` and `.enable_tools()` were still inside that guard. Generated servers without migration tooling compiled with undefined types.

## Root cause

Commit `f261172` made `get_version` an always-present tool, but left the type imports and `enable_tools()` capability conditional on `has_tools` (which is only true when `--migrations` is supplied). The mismatch went undetected because no test compiled the generated output.

## Fix

Unconditionally import the five tool types and enable the tools capability; keep only migration-specific imports (`gen_orb_mcp`), constant (`CONFORMANCE_RULES_JSON`), and match arms (`plan_migration`, `apply_migration`) behind `{{#if has_tools}}`.

## Test plan

- [ ] `cargo test --all` passes (194 unit tests + 1 new compilation integration test)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)