### PR TITLE
feat: add build, publish, and save subcommands (tier 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -101,6 +101,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -174,6 +180,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -184,14 +192,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -269,6 +285,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +310,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -442,6 +481,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +521,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +552,27 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
  "crypto-common 0.2.1",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -517,6 +599,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,7 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -682,14 +779,17 @@ dependencies = [
  "chrono",
  "clap",
  "criterion",
+ "git2",
+ "git2_credentials",
  "handlebars",
+ "octocrate",
  "pmcp",
  "semver",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -708,6 +808,33 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
@@ -715,10 +842,39 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
+name = "git2_credentials"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5ef5b71f0b7c38b9fab78d33a071100a3a3d6f82d80bc8e53ba4b82b6487ed"
+dependencies = [
+ "dialoguer",
+ "dirs",
+ "git2",
+ "pest",
+ "pest_derive",
+ "regex",
 ]
 
 [[package]]
@@ -726,6 +882,25 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "half"
@@ -751,7 +926,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -815,6 +990,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +1018,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -990,6 +1233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1260,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1277,21 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1039,6 +1313,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.4+1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,6 +1336,32 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1078,6 +1392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,7 +1426,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1115,7 +1441,32 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1143,6 +1494,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "octocrate"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d485e5ea679c01f7021fcfc41a1de0f5c6928bb53f978a21e4f5de4a76c02afb"
+dependencies = [
+ "octocrate-core",
+ "octocrate-types",
+ "serde",
+ "serde_json",
+ "typed-builder",
+]
+
+[[package]]
+name = "octocrate-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa0936710022a97ddddf43dbb2e818e84d93b3325ddb19df268353f61b62df8"
+dependencies = [
+ "chrono",
+ "jsonwebtoken",
+ "octocrate-types",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "octocrate-types"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6addcf2f8351ee10953f65200c77c616f02e0ab1919a1fb56d1eddd82a9030ac"
+dependencies = [
+ "serde",
+ "serde_json",
+ "typed-builder",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,13 +1553,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1201,6 +1617,16 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -1259,6 +1685,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,7 +1738,7 @@ dependencies = [
  "futures",
  "futures-channel",
  "futures-locks",
- "getrandom",
+ "getrandom 0.4.2",
  "glob",
  "http",
  "http-body-util",
@@ -1319,7 +1751,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1350,6 +1782,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1816,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,9 +1881,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rayon"
@@ -1422,6 +1959,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,6 +1999,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,7 +2072,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1550,6 +2197,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,6 +2253,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,6 +2279,18 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "slab"
@@ -1649,7 +2326,7 @@ dependencies = [
  "tempfile",
  "wait-timeout",
  "walkdir",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1668,7 +2345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1684,6 +2361,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,6 +2375,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -1706,16 +2398,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1724,7 +2446,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1748,6 +2481,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,6 +2532,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,7 +2560,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1793,6 +2572,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1875,6 +2664,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,6 +2770,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "trycmd"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,6 +2791,26 @@ dependencies = [
  "shlex",
  "snapbox",
  "toml_edit",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77739c880e00693faef3d65ea3aad725f196da38b22fdc7ea6ded6e1ce4d3add"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1972,6 +2832,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,6 +2848,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2019,7 +2891,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -2030,6 +2902,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2054,6 +2932,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2162,6 +3049,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,6 +3081,25 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2205,7 +3124,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2256,6 +3175,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,12 +3205,234 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -2448,6 +3600,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,17 @@ chrono = { version = "0.4.44", features = ["std"], default-features = false }
 # Semantic versioning — for --earliest-version comparison and version sorting
 semver = "1.0.28"
 
+# GitHub REST API — typed access for publish subcommand
+octocrate = { version = "2.2.0", default-features = false, features = [
+    "repos",
+    "file-body",
+    "rustls-tls",
+] }
+
+# Git operations — staging, committing, pushing for the save subcommand
+git2 = "0.20.4"
+git2_credentials = "0.15.0"
+
 # Testing
 tempfile = "3.27.0"
 trycmd = "1.2.0"

--- a/crates/gen-orb-mcp/Cargo.toml
+++ b/crates/gen-orb-mcp/Cargo.toml
@@ -41,6 +41,13 @@ tracing-subscriber.workspace = true
 chrono.workspace = true
 semver.workspace = true
 
+# GitHub REST API (for publish subcommand)
+octocrate.workspace = true
+
+# Git operations (for save subcommand)
+git2.workspace = true
+git2_credentials.workspace = true
+
 [dev-dependencies]
 tempfile.workspace = true
 trycmd.workspace = true

--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -208,6 +208,24 @@ enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Compile generated MCP server source to a native binary
+    Build {
+        /// Directory containing generated MCP server source
+        #[arg(short = 'i', long)]
+        input: std::path::PathBuf,
+
+        /// Override the binary name (default: derived from Cargo.toml)
+        #[arg(short = 'n', long)]
+        name: Option<String>,
+
+        /// Rust target triple (default: host)
+        #[arg(long)]
+        target: Option<String>,
+
+        /// Print the cargo command without running it
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 /// Output format for generated MCP server
@@ -289,6 +307,12 @@ impl Cli {
                 *ephemeral,
                 *dry_run,
             ),
+            Commands::Build {
+                input,
+                name,
+                target,
+                dry_run,
+            } => run_build(input, name.as_deref(), target.as_deref(), *dry_run),
         }
     }
 }
@@ -666,6 +690,95 @@ fn run_prime(
     );
 
     Ok(())
+}
+
+fn run_build(
+    input: &std::path::Path,
+    name: Option<&str>,
+    target: Option<&str>,
+    dry_run: bool,
+) -> Result<()> {
+    let cargo_toml = input.join("Cargo.toml");
+    if !cargo_toml.exists() {
+        anyhow::bail!(
+            "No Cargo.toml found in input directory: {}",
+            input.display()
+        );
+    }
+
+    let binary_name = match name {
+        Some(n) => n.to_string(),
+        None => read_crate_name(input)?,
+    };
+
+    let mut cargo_args = vec!["build", "--release"];
+    if let Some(t) = target {
+        cargo_args.extend(["--target", t]);
+    }
+
+    let binary_dir = match target {
+        Some(t) => input.join("target").join(t).join("release"),
+        None => input.join("target").join("release"),
+    };
+    let binary_path = binary_dir.join(&binary_name);
+
+    if dry_run {
+        println!("Would run: cargo {}", cargo_args.join(" "));
+        println!("  Input:  {}", input.display());
+        println!("  Binary: {}", binary_path.display());
+        return Ok(());
+    }
+
+    tracing::info!(input = %input.display(), binary = %binary_path.display(), "Compiling MCP server");
+    println!("Compiling MCP server...");
+    let status = std::process::Command::new("cargo")
+        .args(&cargo_args)
+        .current_dir(input)
+        .status()
+        .map_err(|e| anyhow::anyhow!("Failed to run cargo: {}", e))?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "cargo build failed. Source code is available at: {}",
+            input.display()
+        );
+    }
+
+    println!("Successfully compiled MCP server:");
+    println!("  Binary: {}", binary_path.display());
+
+    Ok(())
+}
+
+fn read_crate_name(input: &std::path::Path) -> Result<String> {
+    let content = std::fs::read_to_string(input.join("Cargo.toml"))
+        .map_err(|e| anyhow::anyhow!("Failed to read Cargo.toml: {}", e))?;
+    parse_package_name(&content)
+        .ok_or_else(|| anyhow::anyhow!("Could not find [package] name in Cargo.toml"))
+}
+
+/// Extract the `name` field from the `[package]` section of a Cargo.toml string.
+fn parse_package_name(toml: &str) -> Option<String> {
+    let mut in_package = false;
+    for line in toml.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[package]" {
+            in_package = true;
+        } else if trimmed.starts_with('[') {
+            in_package = false;
+        } else if in_package {
+            if let Some(rest) = trimmed.strip_prefix("name") {
+                let rest = rest.trim();
+                if let Some(rest) = rest.strip_prefix('=') {
+                    let name = rest.trim().trim_matches('"').trim_matches('\'').to_string();
+                    if !name.is_empty() {
+                        return Some(name);
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Walk up from `start` looking for a `.git` directory.
@@ -1243,6 +1356,124 @@ mod tests {
             assert_eq!(tag_prefix, "v");
         } else {
             panic!("expected Generate variant");
+        }
+    }
+
+    // --- build subcommand tests ---
+
+    fn write_cargo_toml(dir: &std::path::Path, name: &str) {
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            format!("[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_build_missing_cargo_toml_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let result = run_build(dir.path(), None, None, false);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("Cargo.toml"),
+            "error should mention Cargo.toml, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_build_dry_run_does_not_invoke_cargo() {
+        let dir = TempDir::new().unwrap();
+        write_cargo_toml(dir.path(), "my-server");
+        // Not a valid Rust project — cargo would fail if invoked.
+        // With dry_run=true the function must succeed without running cargo.
+        let result = run_build(dir.path(), None, None, true);
+        assert!(
+            result.is_ok(),
+            "dry_run should succeed without invoking cargo: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_build_name_override_accepted_in_dry_run() {
+        let dir = TempDir::new().unwrap();
+        write_cargo_toml(dir.path(), "my-server");
+        let result = run_build(dir.path(), Some("custom-name"), None, true);
+        assert!(result.is_ok(), "name override + dry_run should succeed: {result:?}");
+    }
+
+    #[test]
+    fn test_build_target_triple_accepted_in_dry_run() {
+        let dir = TempDir::new().unwrap();
+        write_cargo_toml(dir.path(), "my-server");
+        let result = run_build(dir.path(), None, Some("x86_64-unknown-linux-musl"), true);
+        assert!(result.is_ok(), "target + dry_run should succeed: {result:?}");
+    }
+
+    #[test]
+    fn test_parse_package_name_extracts_name() {
+        let toml = "[package]\nname = \"my-orb-mcp\"\nversion = \"0.1.0\"\n";
+        assert_eq!(
+            parse_package_name(toml),
+            Some("my-orb-mcp".to_string()),
+            "should extract package name"
+        );
+    }
+
+    #[test]
+    fn test_parse_package_name_stops_at_next_section() {
+        let toml = "[package]\nname = \"my-orb-mcp\"\n[dependencies]\nname = \"ignored\"\n";
+        assert_eq!(parse_package_name(toml), Some("my-orb-mcp".to_string()));
+    }
+
+    #[test]
+    fn test_parse_package_name_returns_none_when_absent() {
+        let toml = "[dependencies]\nanyhow = \"1\"\n";
+        assert_eq!(parse_package_name(toml), None);
+    }
+
+    #[test]
+    fn test_read_crate_name_from_file() {
+        let dir = TempDir::new().unwrap();
+        write_cargo_toml(dir.path(), "test-crate");
+        let result = read_crate_name(dir.path());
+        assert!(result.is_ok(), "read_crate_name should succeed: {result:?}");
+        assert_eq!(result.unwrap(), "test-crate");
+    }
+
+    #[test]
+    fn test_cli_parse_build_required_input() {
+        let cli = Cli::try_parse_from(["gen-orb-mcp", "build", "--input", "/tmp/my-server"]);
+        assert!(cli.is_ok(), "build --input should parse");
+    }
+
+    #[test]
+    fn test_cli_parse_build_all_flags() {
+        let cli = Cli::try_parse_from([
+            "gen-orb-mcp",
+            "build",
+            "--input",
+            "/tmp/my-server",
+            "--name",
+            "my_server",
+            "--target",
+            "x86_64-unknown-linux-musl",
+            "--dry-run",
+        ]);
+        assert!(cli.is_ok(), "build with all flags should parse");
+        if let Commands::Build {
+            input,
+            name,
+            target,
+            dry_run,
+        } = cli.unwrap().command
+        {
+            assert_eq!(input.to_str().unwrap(), "/tmp/my-server");
+            assert_eq!(name.as_deref(), Some("my_server"));
+            assert_eq!(target.as_deref(), Some("x86_64-unknown-linux-musl"));
+            assert!(dry_run);
+        } else {
+            panic!("expected Build variant");
         }
     }
 }

--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -763,8 +763,34 @@ fn run_save(paths: &[std::path::PathBuf], message: &str, push: bool, dry_run: bo
     let repo = Repository::discover(".")
         .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
 
-    // Stage the requested paths
     let mut index = repo.index()?;
+    save_stage_paths(&mut index, paths)?;
+
+    let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
+    let diff = save_compute_diff(&repo, &mut index, head_commit.as_ref())?;
+
+    if diff.deltas().count() == 0 {
+        println!("Nothing to commit — working tree clean after staging.");
+        return Ok(());
+    }
+
+    if dry_run {
+        save_print_dry_run(&diff, message, push);
+        return Ok(());
+    }
+
+    let oid = save_create_commit(&repo, &mut index, message, head_commit.as_ref())?;
+    tracing::info!(commit = %oid, "Created commit");
+    println!("Created commit {oid}: {message}");
+
+    if push {
+        save_git_push(&repo)?;
+    }
+
+    Ok(())
+}
+
+fn save_stage_paths(index: &mut git2::Index, paths: &[std::path::PathBuf]) -> Result<()> {
     let mut staged_any = false;
     for path in paths {
         if path.exists() {
@@ -777,87 +803,80 @@ fn run_save(paths: &[std::path::PathBuf], message: &str, push: bool, dry_run: bo
     if staged_any {
         index.write()?;
     }
+    Ok(())
+}
 
-    // Check if the tree is clean after staging
-    let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
-    let diff = if let Some(ref commit) = head_commit {
-        let head_tree = commit.tree()?;
-        let new_tree_oid = index.write_tree()?;
-        let new_tree = repo.find_tree(new_tree_oid)?;
-        repo.diff_tree_to_tree(Some(&head_tree), Some(&new_tree), None)?
-    } else {
-        let new_tree_oid = index.write_tree()?;
-        let new_tree = repo.find_tree(new_tree_oid)?;
-        repo.diff_tree_to_tree(None, Some(&new_tree), None)?
-    };
+fn save_compute_diff<'repo>(
+    repo: &'repo git2::Repository,
+    index: &mut git2::Index,
+    head_commit: Option<&git2::Commit<'_>>,
+) -> Result<git2::Diff<'repo>> {
+    let new_tree_oid = index.write_tree()?;
+    let new_tree = repo.find_tree(new_tree_oid)?;
+    let head_tree = head_commit.map(|c| c.tree()).transpose()?;
+    Ok(repo.diff_tree_to_tree(head_tree.as_ref(), Some(&new_tree), None)?)
+}
 
-    if diff.deltas().count() == 0 {
-        println!("Nothing to commit — working tree clean after staging.");
-        return Ok(());
+fn save_print_dry_run(diff: &git2::Diff<'_>, message: &str, push: bool) {
+    println!("Would commit the following changes:");
+    for delta in diff.deltas() {
+        let path = delta
+            .new_file()
+            .path()
+            .and_then(|p| p.to_str())
+            .unwrap_or("(unknown)");
+        println!("  {path}");
     }
-
-    if dry_run {
-        println!("Would commit the following changes:");
-        for delta in diff.deltas() {
-            let path = delta
-                .new_file()
-                .path()
-                .and_then(|p| p.to_str())
-                .unwrap_or("(unknown)");
-            println!("  {path}");
-        }
-        println!("Commit message: {message}");
-        if push {
-            println!("Would push after committing.");
-        }
-        return Ok(());
+    println!("Commit message: {message}");
+    if push {
+        println!("Would push after committing.");
     }
+}
 
-    // Create the commit
+fn save_create_commit(
+    repo: &git2::Repository,
+    index: &mut git2::Index,
+    message: &str,
+    head_commit: Option<&git2::Commit<'_>>,
+) -> Result<git2::Oid> {
     let sig = repo.signature()?;
     let new_tree_oid = index.write_tree()?;
     let new_tree = repo.find_tree(new_tree_oid)?;
+    let parents: Vec<&git2::Commit> = head_commit.into_iter().collect();
+    Ok(repo.commit(Some("HEAD"), &sig, &sig, message, &new_tree, &parents)?)
+}
 
-    let parent_commits: Vec<git2::Commit> = head_commit.into_iter().collect();
-    let parent_refs: Vec<&git2::Commit> = parent_commits.iter().collect();
+fn save_git_push(repo: &git2::Repository) -> Result<()> {
+    let remote_name = repo
+        .remotes()?
+        .iter()
+        .flatten()
+        .next()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "origin".to_string());
 
-    let oid = repo.commit(Some("HEAD"), &sig, &sig, message, &new_tree, &parent_refs)?;
-    tracing::info!(commit = %oid, "Created commit");
-    println!("Created commit {oid}: {message}");
+    let mut callbacks = git2::RemoteCallbacks::new();
+    let git_config = repo.config()?;
+    let mut cred_handler = git2_credentials::CredentialHandler::new(git_config);
+    callbacks.credentials(move |url, username, allowed| {
+        cred_handler.try_next_credential(url, username, allowed)
+    });
 
-    if push {
-        let remote_name = repo
-            .remotes()?
-            .iter()
-            .flatten()
-            .next()
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| "origin".to_string());
+    let mut push_opts = git2::PushOptions::new();
+    push_opts.remote_callbacks(callbacks);
 
-        let mut callbacks = git2::RemoteCallbacks::new();
-        let git_config = repo.config()?;
-        let mut cred_handler = git2_credentials::CredentialHandler::new(git_config);
-        callbacks.credentials(move |url, username, allowed| {
-            cred_handler.try_next_credential(url, username, allowed)
-        });
+    let head_ref = repo.head()?;
+    let branch_name = head_ref
+        .shorthand()
+        .ok_or_else(|| anyhow::anyhow!("HEAD has no branch name"))?;
+    let refspec = format!("refs/heads/{branch_name}:refs/heads/{branch_name}");
 
-        let mut push_opts = git2::PushOptions::new();
-        push_opts.remote_callbacks(callbacks);
+    let mut remote = repo.find_remote(&remote_name)?;
+    remote
+        .push(&[refspec.as_str()], Some(&mut push_opts))
+        .map_err(|e| anyhow::anyhow!("Push failed: {}", e))?;
 
-        let head_ref = repo.head()?;
-        let branch_name = head_ref
-            .shorthand()
-            .ok_or_else(|| anyhow::anyhow!("HEAD has no branch name"))?;
-        let refspec = format!("refs/heads/{branch_name}:refs/heads/{branch_name}");
-
-        let mut remote = repo.find_remote(&remote_name)?;
-        remote
-            .push(&[refspec.as_str()], Some(&mut push_opts))
-            .map_err(|e| anyhow::anyhow!("Push failed: {}", e))?;
-
-        println!("Pushed to {remote_name}/{branch_name}");
-    }
-
+    println!("Pushed to {remote_name}/{branch_name}");
     Ok(())
 }
 

--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -208,6 +208,58 @@ enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Stage, commit, and push generated artifacts back to the repository
+    ///
+    /// Idempotent: if the working tree is clean after staging the specified
+    /// paths, exits successfully without creating an empty commit.
+    /// The default commit message includes [skip ci] to prevent CI re-triggering.
+    Save {
+        /// Paths to stage and commit (relative to repository root)
+        #[arg(required = true)]
+        paths: Vec<std::path::PathBuf>,
+
+        /// Commit message
+        #[arg(
+            short = 'm',
+            long,
+            default_value = "chore: update generated MCP server artifacts [skip ci]"
+        )]
+        message: String,
+
+        /// Push after committing (default: true)
+        #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+        push: bool,
+
+        /// Stage and commit only, do not push
+        #[arg(long, conflicts_with = "push")]
+        no_push: bool,
+
+        /// Show what would be committed without writing anything
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Upload a compiled binary to an existing GitHub release as a release asset
+    ///
+    /// The GitHub release must already exist before this command is run.
+    /// Set GITHUB_TOKEN, CIRCLE_PROJECT_USERNAME, CIRCLE_PROJECT_REPONAME,
+    /// and CIRCLE_TAG (or use --tag) in the environment.
+    Publish {
+        /// Path to the binary file to upload
+        #[arg(short = 'b', long)]
+        binary: std::path::PathBuf,
+
+        /// Name for the release asset (e.g. my-orb-mcp-linux-x86_64)
+        #[arg(short = 'a', long)]
+        asset_name: String,
+
+        /// Release tag to publish to (default: $CIRCLE_TAG)
+        #[arg(long)]
+        tag: Option<String>,
+
+        /// Describe the upload without performing it
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Compile generated MCP server source to a native binary
     Build {
         /// Directory containing generated MCP server source
@@ -307,6 +359,19 @@ impl Cli {
                 *ephemeral,
                 *dry_run,
             ),
+            Commands::Save {
+                paths,
+                message,
+                push,
+                no_push,
+                dry_run,
+            } => run_save(paths, message, *push && !*no_push, *dry_run),
+            Commands::Publish {
+                binary,
+                asset_name,
+                tag,
+                dry_run,
+            } => run_publish(binary, asset_name, tag.as_deref(), *dry_run),
             Commands::Build {
                 input,
                 name,
@@ -688,6 +753,219 @@ fn run_prime(
         result.migrations_added,
         result.migrations_removed,
     );
+
+    Ok(())
+}
+
+fn run_save(paths: &[std::path::PathBuf], message: &str, push: bool, dry_run: bool) -> Result<()> {
+    use git2::Repository;
+
+    let repo = Repository::discover(".")
+        .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
+
+    // Stage the requested paths
+    let mut index = repo.index()?;
+    let mut staged_any = false;
+    for path in paths {
+        if path.exists() {
+            index.add_path(path)?;
+            staged_any = true;
+        } else {
+            tracing::warn!(path = %path.display(), "Path does not exist, skipping");
+        }
+    }
+    if staged_any {
+        index.write()?;
+    }
+
+    // Check if the tree is clean after staging
+    let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
+    let diff = if let Some(ref commit) = head_commit {
+        let head_tree = commit.tree()?;
+        let new_tree_oid = index.write_tree()?;
+        let new_tree = repo.find_tree(new_tree_oid)?;
+        repo.diff_tree_to_tree(Some(&head_tree), Some(&new_tree), None)?
+    } else {
+        let new_tree_oid = index.write_tree()?;
+        let new_tree = repo.find_tree(new_tree_oid)?;
+        repo.diff_tree_to_tree(None, Some(&new_tree), None)?
+    };
+
+    if diff.deltas().count() == 0 {
+        println!("Nothing to commit — working tree clean after staging.");
+        return Ok(());
+    }
+
+    if dry_run {
+        println!("Would commit the following changes:");
+        for delta in diff.deltas() {
+            let path = delta
+                .new_file()
+                .path()
+                .and_then(|p| p.to_str())
+                .unwrap_or("(unknown)");
+            println!("  {path}");
+        }
+        println!("Commit message: {message}");
+        if push {
+            println!("Would push after committing.");
+        }
+        return Ok(());
+    }
+
+    // Create the commit
+    let sig = repo.signature()?;
+    let new_tree_oid = index.write_tree()?;
+    let new_tree = repo.find_tree(new_tree_oid)?;
+
+    let parent_commits: Vec<git2::Commit> = head_commit.into_iter().collect();
+    let parent_refs: Vec<&git2::Commit> = parent_commits.iter().collect();
+
+    let oid = repo.commit(Some("HEAD"), &sig, &sig, message, &new_tree, &parent_refs)?;
+    tracing::info!(commit = %oid, "Created commit");
+    println!("Created commit {oid}: {message}");
+
+    if push {
+        let remote_name = repo
+            .remotes()?
+            .iter()
+            .flatten()
+            .next()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "origin".to_string());
+
+        let mut callbacks = git2::RemoteCallbacks::new();
+        let git_config = repo.config()?;
+        let mut cred_handler = git2_credentials::CredentialHandler::new(git_config);
+        callbacks.credentials(move |url, username, allowed| {
+            cred_handler.try_next_credential(url, username, allowed)
+        });
+
+        let mut push_opts = git2::PushOptions::new();
+        push_opts.remote_callbacks(callbacks);
+
+        let head_ref = repo.head()?;
+        let branch_name = head_ref
+            .shorthand()
+            .ok_or_else(|| anyhow::anyhow!("HEAD has no branch name"))?;
+        let refspec = format!("refs/heads/{branch_name}:refs/heads/{branch_name}");
+
+        let mut remote = repo.find_remote(&remote_name)?;
+        remote
+            .push(&[refspec.as_str()], Some(&mut push_opts))
+            .map_err(|e| anyhow::anyhow!("Push failed: {}", e))?;
+
+        println!("Pushed to {remote_name}/{branch_name}");
+    }
+
+    Ok(())
+}
+
+fn run_publish(
+    binary: &std::path::Path,
+    asset_name: &str,
+    tag: Option<&str>,
+    dry_run: bool,
+) -> Result<()> {
+    if !binary.exists() {
+        anyhow::bail!("Binary not found: {}", binary.display());
+    }
+
+    let token = std::env::var("GITHUB_TOKEN")
+        .map_err(|_| anyhow::anyhow!("GITHUB_TOKEN environment variable is not set"))?;
+
+    let resolved_tag = match tag {
+        Some(t) => t.to_string(),
+        None => std::env::var("CIRCLE_TAG").map_err(|_| {
+            anyhow::anyhow!("No release tag provided. Set CIRCLE_TAG or use --tag <TAG>")
+        })?,
+    };
+
+    let owner = std::env::var("CIRCLE_PROJECT_USERNAME").unwrap_or_default();
+    let repo = std::env::var("CIRCLE_PROJECT_REPONAME").unwrap_or_default();
+
+    if dry_run {
+        println!("Would upload release asset (dry run):");
+        println!("  Binary:     {}", binary.display());
+        println!("  Asset name: {asset_name}");
+        println!("  Tag:        {resolved_tag}");
+        if !owner.is_empty() && !repo.is_empty() {
+            println!("  Repo:       {owner}/{repo}");
+        }
+        return Ok(());
+    }
+
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?
+        .block_on(upload_release_asset(
+            &token,
+            &owner,
+            &repo,
+            &resolved_tag,
+            binary,
+            asset_name,
+        ))
+}
+
+async fn upload_release_asset(
+    token: &str,
+    owner: &str,
+    repo: &str,
+    tag: &str,
+    binary: &std::path::Path,
+    asset_name: &str,
+) -> Result<()> {
+    use octocrate::repos;
+    use octocrate::{APIConfig, GitHubAPI, PersonalAccessToken};
+
+    let pat = PersonalAccessToken::new(token);
+    let config = APIConfig::with_token(pat).shared();
+    let api = GitHubAPI::new(&config);
+
+    tracing::info!(owner, repo, tag, "Looking up GitHub release");
+    let release = api
+        .repos
+        .get_release_by_tag(owner, repo, tag)
+        .send()
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Release not found for tag '{}' in {}/{}: {}",
+                tag,
+                owner,
+                repo,
+                e
+            )
+        })?;
+
+    tracing::info!(release_id = release.id, "Found release");
+
+    let file = tokio::fs::File::open(binary)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to open binary '{}': {}", binary.display(), e))?;
+    let file_size = file.metadata().await?.len();
+
+    let query = repos::upload_release_asset::Query::builder()
+        .name(asset_name)
+        .build();
+
+    tracing::info!(asset_name, bytes = file_size, "Uploading asset");
+
+    let result = api
+        .repos
+        .upload_release_asset(owner, repo, release.id)
+        .query(&query)
+        .header("Content-Type", "application/octet-stream")
+        .header("Content-Length", file_size.to_string())
+        .file(file)
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to upload asset '{}': {}", asset_name, e))?;
+
+    println!("Successfully uploaded release asset:");
+    println!("  Asset: {}", result.name);
+    println!("  URL:   {}", result.browser_download_url);
 
     Ok(())
 }
@@ -1359,6 +1637,270 @@ mod tests {
         }
     }
 
+    // --- save subcommand tests ---
+
+    fn init_git_repo(dir: &std::path::Path) {
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        // Initial commit so HEAD exists
+        std::fs::write(dir.join("README.md"), "test").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+    }
+
+    #[test]
+    fn test_save_clean_tree_exits_without_commit() {
+        let dir = TempDir::new().unwrap();
+        init_git_repo(dir.path());
+        let _cwd_guard = CWD_LOCK.lock().unwrap();
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        // Stage the path we already committed — tree is clean after staging
+        let result = run_save(
+            &[std::path::PathBuf::from("README.md")],
+            "chore: test",
+            false,
+            false,
+        );
+        std::env::set_current_dir(&original).unwrap();
+        assert!(
+            result.is_ok(),
+            "clean tree should exit 0 without creating a commit: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_save_changed_path_creates_commit() {
+        let dir = TempDir::new().unwrap();
+        init_git_repo(dir.path());
+        std::fs::write(dir.path().join("new-file.txt"), "hello").unwrap();
+        let _cwd_guard = CWD_LOCK.lock().unwrap();
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let result = run_save(
+            &[std::path::PathBuf::from("new-file.txt")],
+            "chore: add generated file",
+            false,
+            false,
+        );
+        std::env::set_current_dir(&original).unwrap();
+        assert!(
+            result.is_ok(),
+            "changed path should commit successfully: {result:?}"
+        );
+        // Verify a commit was created beyond the initial one
+        let log = std::process::Command::new("git")
+            .args(["log", "--oneline"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        let log_str = String::from_utf8_lossy(&log.stdout);
+        assert!(
+            log_str.lines().count() >= 2,
+            "expected at least 2 commits, got: {log_str}"
+        );
+    }
+
+    #[test]
+    fn test_save_dry_run_does_not_commit() {
+        let dir = TempDir::new().unwrap();
+        init_git_repo(dir.path());
+        std::fs::write(dir.path().join("artifact.txt"), "generated").unwrap();
+        let _cwd_guard = CWD_LOCK.lock().unwrap();
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let result = run_save(
+            &[std::path::PathBuf::from("artifact.txt")],
+            "chore: generated",
+            false,
+            true,
+        );
+        std::env::set_current_dir(&original).unwrap();
+        assert!(result.is_ok(), "dry_run should succeed: {result:?}");
+        // Only the initial commit should exist
+        let log = std::process::Command::new("git")
+            .args(["log", "--oneline"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        let log_str = String::from_utf8_lossy(&log.stdout);
+        assert_eq!(
+            log_str.lines().count(),
+            1,
+            "dry_run must not create a commit, got: {log_str}"
+        );
+    }
+
+    #[test]
+    fn test_cli_parse_save_required_paths() {
+        let cli = Cli::try_parse_from(["gen-orb-mcp", "save", "prior-versions", "migrations"]);
+        assert!(cli.is_ok(), "save with paths should parse");
+    }
+
+    #[test]
+    fn test_cli_parse_save_all_flags() {
+        let cli = Cli::try_parse_from([
+            "gen-orb-mcp",
+            "save",
+            "prior-versions",
+            "--message",
+            "custom message",
+            "--no-push",
+            "--dry-run",
+        ]);
+        assert!(cli.is_ok(), "save with all flags should parse");
+        if let Commands::Save {
+            paths,
+            message,
+            no_push,
+            dry_run,
+            ..
+        } = cli.unwrap().command
+        {
+            assert_eq!(paths, vec![std::path::PathBuf::from("prior-versions")]);
+            assert_eq!(message, "custom message");
+            assert!(no_push);
+            assert!(dry_run);
+        } else {
+            panic!("expected Save variant");
+        }
+    }
+
+    // --- publish subcommand tests ---
+
+    #[test]
+    fn test_publish_missing_binary_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let result = run_publish(
+            &dir.path().join("missing-binary"),
+            "asset.tar.gz",
+            None,
+            false,
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("Binary not found"),
+            "error should mention missing binary, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_publish_dry_run_with_missing_token_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let binary = dir.path().join("my-binary");
+        std::fs::write(&binary, b"fake binary").unwrap();
+        // dry_run without GITHUB_TOKEN should fail before attempting any API call
+        std::env::remove_var("GITHUB_TOKEN");
+        let result = run_publish(&binary, "my-asset", Some("v1.0.0"), true);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("GITHUB_TOKEN"),
+            "error should mention GITHUB_TOKEN, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_publish_dry_run_missing_tag_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let binary = dir.path().join("my-binary");
+        std::fs::write(&binary, b"fake binary").unwrap();
+        std::env::set_var("GITHUB_TOKEN", "fake-token");
+        std::env::remove_var("CIRCLE_TAG");
+        // no --tag and no CIRCLE_TAG — should fail with a clear message
+        let result = run_publish(&binary, "my-asset", None, true);
+        std::env::remove_var("GITHUB_TOKEN");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("tag") || msg.contains("CIRCLE_TAG"),
+            "error should mention tag or CIRCLE_TAG, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_publish_dry_run_prints_parameters() {
+        let dir = TempDir::new().unwrap();
+        let binary = dir.path().join("my-binary");
+        std::fs::write(&binary, b"fake binary").unwrap();
+        std::env::set_var("GITHUB_TOKEN", "fake-token");
+        std::env::set_var("CIRCLE_PROJECT_USERNAME", "jerus-org");
+        std::env::set_var("CIRCLE_PROJECT_REPONAME", "my-orb");
+        let result = run_publish(&binary, "my-asset-linux-x86_64", Some("v1.0.0"), true);
+        std::env::remove_var("GITHUB_TOKEN");
+        std::env::remove_var("CIRCLE_PROJECT_USERNAME");
+        std::env::remove_var("CIRCLE_PROJECT_REPONAME");
+        assert!(
+            result.is_ok(),
+            "dry_run with all params should succeed: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_cli_parse_publish_required_args() {
+        let cli = Cli::try_parse_from([
+            "gen-orb-mcp",
+            "publish",
+            "--binary",
+            "/tmp/my-binary",
+            "--asset-name",
+            "my-binary-linux-x86_64",
+        ]);
+        assert!(cli.is_ok(), "publish with required args should parse");
+    }
+
+    #[test]
+    fn test_cli_parse_publish_all_flags() {
+        let cli = Cli::try_parse_from([
+            "gen-orb-mcp",
+            "publish",
+            "--binary",
+            "/tmp/my-binary",
+            "--asset-name",
+            "my-binary-linux-x86_64",
+            "--tag",
+            "v2.0.0",
+            "--dry-run",
+        ]);
+        assert!(cli.is_ok(), "publish with all flags should parse");
+        if let Commands::Publish {
+            binary,
+            asset_name,
+            tag,
+            dry_run,
+        } = cli.unwrap().command
+        {
+            assert_eq!(binary.to_str().unwrap(), "/tmp/my-binary");
+            assert_eq!(asset_name, "my-binary-linux-x86_64");
+            assert_eq!(tag.as_deref(), Some("v2.0.0"));
+            assert!(dry_run);
+        } else {
+            panic!("expected Publish variant");
+        }
+    }
+
     // --- build subcommand tests ---
 
     fn write_cargo_toml(dir: &std::path::Path, name: &str) {
@@ -1399,7 +1941,10 @@ mod tests {
         let dir = TempDir::new().unwrap();
         write_cargo_toml(dir.path(), "my-server");
         let result = run_build(dir.path(), Some("custom-name"), None, true);
-        assert!(result.is_ok(), "name override + dry_run should succeed: {result:?}");
+        assert!(
+            result.is_ok(),
+            "name override + dry_run should succeed: {result:?}"
+        );
     }
 
     #[test]
@@ -1407,7 +1952,10 @@ mod tests {
         let dir = TempDir::new().unwrap();
         write_cargo_toml(dir.path(), "my-server");
         let result = run_build(dir.path(), None, Some("x86_64-unknown-linux-musl"), true);
-        assert!(result.is_ok(), "target + dry_run should succeed: {result:?}");
+        assert!(
+            result.is_ok(),
+            "target + dry_run should succeed: {result:?}"
+        );
     }
 
     #[test]

--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -1064,18 +1064,20 @@ fn parse_package_name(toml: &str) -> Option<String> {
         } else if trimmed.starts_with('[') {
             in_package = false;
         } else if in_package {
-            if let Some(rest) = trimmed.strip_prefix("name") {
-                let rest = rest.trim();
-                if let Some(rest) = rest.strip_prefix('=') {
-                    let name = rest.trim().trim_matches('"').trim_matches('\'').to_string();
-                    if !name.is_empty() {
-                        return Some(name);
-                    }
-                }
+            if let Some(name) = parse_name_assignment(trimmed) {
+                return Some(name);
             }
         }
     }
     None
+}
+
+/// Parse a `name = "value"` assignment line, returning the unquoted value.
+fn parse_name_assignment(line: &str) -> Option<String> {
+    let rest = line.strip_prefix("name")?;
+    let rest = rest.trim().strip_prefix('=')?;
+    let name = rest.trim().trim_matches('"').trim_matches('\'').to_string();
+    (!name.is_empty()).then_some(name)
 }
 
 /// Walk up from `start` looking for a `.git` directory.


### PR DESCRIPTION
## Summary

- Adds `build` subcommand: compiles generated MCP server source to a native binary via `cargo build --release`; supports `--name`, `--target`, `--dry-run`
- Adds `publish` subcommand: uploads a compiled binary to an existing GitHub release asset using `octocrate`; reads `GITHUB_TOKEN`, `CIRCLE_PROJECT_USERNAME/REPONAME`, `CIRCLE_TAG` from env; supports `--tag` override and `--dry-run`
- Adds `save` subcommand: stages, commits, and pushes generated artifacts back to the repository using `git2` + `git2_credentials`; idempotent (no empty commit if tree is clean after staging); supports `--no-push` and `--dry-run`
- Adds `octocrate` (2.2.0), `git2` (0.20.4), `git2_credentials` (0.15.0) as workspace dependencies
- 24 new unit tests (TDD: RED then GREEN for each subcommand)

These three subcommands close the gap in the pipeline described in `docs/NEXT_PHASE_PLAN.md` — consumers can now run the complete prime → generate → build → publish → save workflow using only orb jobs.

## Test plan

- [x] `cargo test -p gen-orb-mcp` — 215 passed, 0 failed
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --all --tests --all-features -- -D warnings` — clean
- [x] `cargo audit` — no advisories

🤖 Generated with [Claude Code](https://claude.com/claude-code)