### PR TITLE
docs: update docs and orb for tier 2 (build/publish/save)

### DIFF
--- a/crates/gen-orb-mcp/README.md
+++ b/crates/gen-orb-mcp/README.md
@@ -160,6 +160,9 @@ orbs:
 | `diff` | `current`, `previous`, `since_version` | Compute conformance rules between two orb versions |
 | `migrate` | `orb`, `rules` | Apply migration rules to a consumer CI directory |
 | `prime` | — | Populate `prior-versions/` and `migrations/` from git history |
+| `build` | `input` | Compile generated MCP server source to a native binary |
+| `publish` | `binary`, `asset_name` | Upload compiled binary to an existing GitHub release |
+| `save` | `paths` | Stage, commit, and push generated artifacts back to the repo |
 
 ### Example: generate an MCP server from your orb in CI
 
@@ -176,27 +179,48 @@ workflows:
           version: "1.0.0"
 ```
 
-### Example: full prime → generate pipeline
+### Example: complete release pipeline
+
+Generate, compile, upload, and save in one automated workflow:
 
 ```yaml
 orbs:
   gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.11
 
 workflows:
-  build:
+  release:
     jobs:
       - gen-orb-mcp/prime:
           orb_path: src/@orb.yml
-          earliest_version: "4.1.0"
+          earliest_version: "1.0.0"
           ephemeral: true
+
       - gen-orb-mcp/generate:
+          requires: [gen-orb-mcp/prime]
           orb_path: src/@orb.yml
-          output: ./mcp-server
-          version: "6.0.0"
+          output: /tmp/mcp-build
+          version: "${CIRCLE_TAG#v}"
           migrations: /tmp/gen-orb-mcp-prime/migrations
           prior_versions: /tmp/gen-orb-mcp-prime/prior-versions
-          requires: [gen-orb-mcp/prime]
+
+      - gen-orb-mcp/build:
+          requires: [gen-orb-mcp/generate]
+          input: /tmp/mcp-build
+
+      - gen-orb-mcp/publish:
+          requires: [gen-orb-mcp/build]
+          binary: /tmp/mcp-build/target/release/my_orb_mcp
+          asset_name: my-orb-mcp-linux-x86_64
+          context: github-release  # must provide GITHUB_TOKEN
+
+      - gen-orb-mcp/save:
+          requires: [gen-orb-mcp/generate]
+          paths: prior-versions migrations
+          context: github-push     # must provide push credentials
 ```
+
+`save` runs in parallel with `build` (both require `generate`), so the artifact commit
+does not block the binary upload.
 
 The orb source is regenerated automatically on every build by
 [gen-circleci-orb](https://github.com/jerus-org/gen-circleci-orb), which introspects
@@ -276,6 +300,62 @@ Options:
       --rules <FILE>    Path to conformance rules JSON (produced by diff)
       --dry-run         Show planned changes without modifying files
 ```
+
+### `build` — Compile generated MCP server source
+
+```
+gen-orb-mcp build [OPTIONS] --input <DIR>
+
+Options:
+  -i, --input <DIR>     Directory containing generated Cargo.toml (required)
+  -n, --name <NAME>     Binary name (default: read from Cargo.toml [package] name)
+      --target <TRIPLE> Cargo target triple for cross-compilation (optional)
+      --dry-run         Print what would run without executing cargo build
+```
+
+Runs `cargo build --release` inside `<input>`. On success, prints the path to the compiled binary.
+The release does not need a pre-existing Rust toolchain beyond what is available in the CI executor.
+
+### `publish` — Upload a binary to a GitHub release
+
+```
+gen-orb-mcp publish [OPTIONS] --binary <PATH> --asset-name <NAME>
+
+Options:
+  -b, --binary <PATH>       Path to the compiled binary file (required)
+  -a, --asset-name <NAME>   Name of the release asset as it appears on GitHub (required)
+      --tag <TAG>            Git tag identifying the release [default: $CIRCLE_TAG]
+      --dry-run              Print what would be uploaded without calling the API
+```
+
+**Prerequisite**: the GitHub release must already exist. `publish` only adds an asset — it does
+not create the release. Environment variables read at runtime:
+
+| Variable | Purpose |
+|---|---|
+| `GITHUB_TOKEN` | Personal access token with `contents: write` |
+| `CIRCLE_PROJECT_USERNAME` | Repository owner |
+| `CIRCLE_PROJECT_REPONAME` | Repository name |
+| `CIRCLE_TAG` | Tag used to locate the release (overridden by `--tag`) |
+
+### `save` — Stage, commit, and push generated artifacts
+
+```
+gen-orb-mcp save [OPTIONS] <PATHS>...
+
+Arguments:
+  <PATHS>...   Paths to stage (files or directories)
+
+Options:
+  -m, --message <MSG>   Commit message [default: "chore: update generated MCP server artifacts [skip ci]"]
+      --push            Push to origin after committing [default: true]
+      --no-push         Skip the push step
+      --dry-run         Stage and diff without creating a commit
+```
+
+Idempotent: if the working tree is clean after staging all paths (no changes), `save` exits 0
+without creating a commit. The default commit message includes `[skip ci]` to prevent CI
+from triggering a new pipeline on the generated artifact commit.
 
 ## How Generated MCP Servers Work
 

--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -215,7 +215,7 @@ enum Commands {
     /// The default commit message includes [skip ci] to prevent CI re-triggering.
     Save {
         /// Paths to stage and commit (relative to repository root)
-        #[arg(required = true)]
+        #[arg(long, required = true)]
         paths: Vec<std::path::PathBuf>,
 
         /// Commit message
@@ -1775,8 +1775,15 @@ mod tests {
 
     #[test]
     fn test_cli_parse_save_required_paths() {
-        let cli = Cli::try_parse_from(["gen-orb-mcp", "save", "prior-versions", "migrations"]);
-        assert!(cli.is_ok(), "save with paths should parse");
+        let cli = Cli::try_parse_from([
+            "gen-orb-mcp",
+            "save",
+            "--paths",
+            "prior-versions",
+            "--paths",
+            "migrations",
+        ]);
+        assert!(cli.is_ok(), "save with --paths should parse");
     }
 
     #[test]
@@ -1784,6 +1791,7 @@ mod tests {
         let cli = Cli::try_parse_from([
             "gen-orb-mcp",
             "save",
+            "--paths",
             "prior-versions",
             "--message",
             "custom message",

--- a/docs/CI_INTEGRATION_GUIDE.md
+++ b/docs/CI_INTEGRATION_GUIDE.md
@@ -61,13 +61,31 @@ steps:
 - Adds install time to every CI run
 - Source compilation can take several minutes if no pre-built binary is available
 
-### Future: Public CircleCI orb
+### gen-orb-mcp orb (recommended)
 
-A public CircleCI orb providing gen-orb-mcp as a reusable job is planned. This would let any orb project add MCP server generation by using the orb directly, without managing tool installation.
+The `jerus-org/gen-orb-mcp` orb exposes every subcommand as a ready-to-use job. This is the
+preferred approach — no tool installation, no custom scripts.
+
+```yaml
+orbs:
+  gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.11
+```
+
+Available jobs: `generate`, `validate`, `diff`, `migrate`, `prime`, `build`, `publish`, `save`.
+See the [README](../crates/gen-orb-mcp/README.md) for the full job reference.
 
 ## CircleCI Pipeline Configuration
 
-### Reusable Commands
+### Using the orb (recommended)
+
+The `jerus-org/gen-orb-mcp` orb provides ready-made jobs. See the
+[QUICKSTART.md](QUICKSTART.md#integrating-into-a-release-pipeline) for the complete
+5-job workflow (`prime → generate → build → publish → save`).
+
+### Manual approach (without the orb)
+
+If you cannot use the orb (e.g. not using CircleCI, or need custom behaviour), the sections
+below show how to wire the equivalent steps manually using reusable commands.
 
 #### generate_mcp_server
 
@@ -249,10 +267,16 @@ Currently only Linux x86_64 is supported (the standard CircleCI executor archite
 
 ## Prerequisites
 
-- **GitHub token** - A `GITHUB_TOKEN` with write access to the GitHub release, provided via a CircleCI context. The upload step creates release assets, which requires `contents: write` permission.
-- **GitHub release** - Must exist before the upload step runs
-- **jq** - Required for parsing GitHub API responses in the upload command
-- **gen-orb-mcp** - Must be available in the executor
+- **GitHub token** — A `GITHUB_TOKEN` with `contents: write` permission, provided via a
+  CircleCI context. Required by both the manual upload command and the `publish` orb job.
+- **GitHub release** — Must exist before the `publish` step runs. `publish` only uploads
+  assets to an existing release; it does not create the release. Create it earlier in your
+  workflow (e.g. via `pcu` or `gh release create`).
+- **gen-orb-mcp** — Must be available in the executor (pre-installed in the container or
+  via runtime `cargo binstall`). Not required when using the orb — the orb executor has it
+  pre-installed.
+- **jq** — Required for parsing GitHub API responses in the manual `upload_release_asset`
+  command only. Not required when using the `publish` orb job.
 
 ## Troubleshooting
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -121,29 +121,55 @@ gen-orb-mcp migrate \
 
 ## Integrating into a release pipeline
 
-In your orb's CircleCI release workflow, add a step after the orb is published:
+Use the `jerus-org/gen-orb-mcp` orb for a fully automated release pipeline.
+Five jobs cover the complete journey from orb YAML to a compiled binary attached to the release:
 
 ```yaml
-- run:
-    name: Generate migration rules
-    command: |
-      gen-orb-mcp diff \
-        --current src/@orb.yml \
-        --previous "$(cat previous-version.yml)" \
-        --since-version "$ORB_VERSION" \
-        --output migrations/"$ORB_VERSION".json
+orbs:
+  gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.11
 
-- run:
-    name: Generate MCP server
-    command: |
-      gen-orb-mcp generate \
-        --orb-path src/@orb.yml \
-        --output dist/mcp \
-        --version "$ORB_VERSION" \
-        --migrations migrations/ \
-        --prior-versions prior-versions/ \
-        --force
+workflows:
+  release:
+    jobs:
+      # 1. Snapshot prior versions and compute migration rules from git tags
+      - gen-orb-mcp/prime:
+          orb_path: src/@orb.yml
+          earliest_version: "1.0.0"
+          ephemeral: true
+
+      # 2. Generate the MCP server source with history and migrations embedded
+      - gen-orb-mcp/generate:
+          requires: [gen-orb-mcp/prime]
+          orb_path: src/@orb.yml
+          output: /tmp/mcp-build
+          version: "${CIRCLE_TAG#v}"
+          migrations: /tmp/gen-orb-mcp-prime/migrations
+          prior_versions: /tmp/gen-orb-mcp-prime/prior-versions
+
+      # 3. Compile the generated source to a native binary
+      - gen-orb-mcp/build:
+          requires: [gen-orb-mcp/generate]
+          input: /tmp/mcp-build
+
+      # 4. Upload the binary to the existing GitHub release
+      - gen-orb-mcp/publish:
+          requires: [gen-orb-mcp/build]
+          binary: /tmp/mcp-build/target/release/my_orb_mcp
+          asset_name: my-orb-mcp-linux-x86_64
+          context: github-release  # must provide GITHUB_TOKEN
+
+      # 5. Commit the generated artifacts (prior-versions, migrations) back to the repo
+      - gen-orb-mcp/save:
+          requires: [gen-orb-mcp/generate]
+          paths: prior-versions migrations
+          context: github-push     # must provide push credentials
 ```
+
+`save` runs in parallel with `build` — both depend only on `generate`, so the artifact commit
+and the binary upload happen simultaneously.
+
+**Prerequisite for `publish`**: the GitHub release for `$CIRCLE_TAG` must already exist before
+this job runs. Create it earlier in your workflow (e.g. via `pcu` or `gh release create`).
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,6 +11,9 @@
 | `diff` | Compute conformance rules between two orb versions → JSON |
 | `migrate` | Apply conformance rules to a consumer's `.circleci/` directory |
 | `prime` | Populate `prior-versions/` and `migrations/` from git tag history |
+| `build` | Compile generated MCP server source to a native binary |
+| `publish` | Upload a compiled binary to an existing GitHub release |
+| `save` | Stage, commit, and push generated artifacts back to the repository |
 
 ### CircleCI Orb (`jerus-org/gen-orb-mcp`)
 
@@ -26,109 +29,6 @@ a job. Consumers wire these jobs into their release workflow to automate the ful
 | `plan_migration` Tool | ✅ (with `--migrations`) |
 | `apply_migration` Tool | ✅ (with `--migrations`) |
 | Compile to native binary | ✅ |
-
----
-
-## Tier 2: Build, Publish, Save (Planned)
-
-### Objective
-
-A consumer should be able to wire a complete, automated pipeline that:
-1. Populates version history (`prime`)
-2. Generates MCP server source with history embedded (`generate`)
-3. Compiles the generated source to a native binary (`build`)
-4. Uploads the binary to an existing GitHub release (`publish`)
-5. Commits the generated artifacts back to the repo (`save`)
-
-Steps 3–5 are the tier 2 additions. Full design: `docs/NEXT_PHASE_PLAN.md`.
-
-### `build` subcommand
-
-Compiles generated MCP server source to a native binary.
-
-```
-gen-orb-mcp build --input <DIR> [--output <DIR>] [--name <NAME>] [--target <TRIPLE>] [--dry-run]
-```
-
-- Verifies `<input>/Cargo.toml` exists, then runs `cargo build --release`
-- Reports binary path on success
-- Orb job: `build` — generated automatically by `gen-circleci-orb`
-
-### `publish` subcommand
-
-Uploads a compiled binary to an existing GitHub release as a release asset.
-
-```
-gen-orb-mcp publish --binary <PATH> --asset-name <NAME> [--tag <TAG>] [--dry-run]
-```
-
-- **Prerequisite**: the GitHub release must already exist; `publish` only uploads assets
-- Resolves the release ID for the tag via the GitHub Releases API
-- Uploads via `octocrate::repos::upload_release_asset` (typed GitHub API client)
-- Environment variables: `GITHUB_TOKEN`, `CIRCLE_PROJECT_USERNAME`,
-  `CIRCLE_PROJECT_REPONAME`, `CIRCLE_TAG`
-- Orb job: `publish` — generated automatically by `gen-circleci-orb`
-
-### `save` subcommand
-
-Stages, commits, and pushes generated artifacts back to the repository.
-
-```
-gen-orb-mcp save [OPTIONS] <PATHS>...
-```
-
-- Idempotent: exits 0 without creating a commit if the working tree is clean after staging
-- Default commit message includes `[skip ci]` to prevent CI re-triggering
-- Implementation: `git2` + `git2_credentials` (same underlying crates as `pcu`)
-- Orb job: `save` — generated automatically by `gen-circleci-orb`
-
-### New Dependencies
-
-```toml
-octocrate = { version = "2.2.0", default-features = false, features = [
-    "repos", "file-body", "rustls-tls",
-] }
-git2 = "0.20.4"
-git2_credentials = "0.15.0"
-```
-
-### Complete Tier 2 Workflow
-
-```yaml
-orbs:
-  gen-orb-mcp: jerus-org/gen-orb-mcp@<version>
-
-workflows:
-  release:
-    jobs:
-      - gen-orb-mcp/prime:
-          orb_path: src/@orb.yml
-          earliest_version: "1.0.0"
-          ephemeral: true
-
-      - gen-orb-mcp/generate:
-          requires: [gen-orb-mcp/prime]
-          orb_path: src/@orb.yml
-          output: /tmp/mcp-build
-          version: "${CIRCLE_TAG#v}"
-          migrations: /tmp/gen-orb-mcp-prime/migrations
-          prior_versions: /tmp/gen-orb-mcp-prime/prior-versions
-
-      - gen-orb-mcp/build:
-          requires: [gen-orb-mcp/generate]
-          input: /tmp/mcp-build
-
-      - gen-orb-mcp/publish:
-          requires: [gen-orb-mcp/build]
-          binary: /tmp/mcp-build/target/release/my_orb_mcp
-          asset_name: my-orb-mcp-linux-x86_64
-          context: github-release
-
-      - gen-orb-mcp/save:
-          requires: [gen-orb-mcp/generate]
-          paths: prior-versions migrations orb/src
-          context: github-push
-```
 
 ---
 
@@ -157,6 +57,25 @@ Examples of tier 3 composed jobs:
 ---
 
 ## Completed Milestones
+
+### Tier 2 — Build, Publish, Save (2026-05)
+
+Completed the automated end-to-end pipeline from orb YAML to a compiled binary attached to a
+GitHub release:
+
+- `build` subcommand: compiles generated MCP server source via `cargo build --release`;
+  reads crate name from `Cargo.toml` when `--name` is omitted; supports `--target` for
+  cross-compilation
+- `publish` subcommand: uploads a compiled binary to an existing GitHub release using
+  `octocrate`; resolves release ID by tag; reads credentials from `GITHUB_TOKEN`,
+  `CIRCLE_PROJECT_USERNAME`, `CIRCLE_PROJECT_REPONAME`, `CIRCLE_TAG`
+- `save` subcommand: stages, commits, and pushes specified paths via `git2` +
+  `git2_credentials`; idempotent (exits 0 if working tree is clean after staging);
+  default commit message includes `[skip ci]`
+- All three subcommands support `--dry-run`
+- Orb updated: `build`, `publish`, `save` jobs generated automatically by `gen-circleci-orb`
+- Full 5-job pipeline achievable with the orb alone: `prime → generate → build → publish`
+  (with `save` running in parallel from `generate`)
 
 ### v0.1.0 — Phase 1 MVP (2024)
 

--- a/orb/Dockerfile
+++ b/orb/Dockerfile
@@ -2,13 +2,13 @@ FROM rust:1-slim-bookworm AS builder
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/* \
-    && cargo install gen-orb-mcp
+    && cargo install ./target/release/gen-orb-mcp
 
 FROM debian:12-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates git \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -ms /bin/bash circleci
-COPY --from=builder /usr/local/cargo/bin/gen-orb-mcp /usr/local/bin/gen-orb-mcp
+COPY --from=builder /usr/local/cargo/bin/./target/release/gen-orb-mcp /usr/local/bin/./target/release/gen-orb-mcp
 USER circleci
 WORKDIR /home/circleci/project

--- a/orb/src/commands/build.yml
+++ b/orb/src/commands/build.yml
@@ -1,0 +1,13 @@
+description: Compile generated MCP server source to a native binary
+parameters:
+  input:
+    type: string
+    description: Directory containing generated MCP server source
+  build_name:
+    type: string
+    description: 'Override the binary name (default: derived from Cargo.toml) --target <TARGET>  Rust target triple (default: host) --dry-run          Print the cargo command without running it'
+    default: ''
+steps:
+- run:
+    name: build
+    command: <<include(scripts/build.sh)>>

--- a/orb/src/commands/publish.yml
+++ b/orb/src/commands/publish.yml
@@ -1,0 +1,20 @@
+description: Upload a compiled binary to an existing GitHub release as a release asset  The GitHub release must already exist before this command is run. Set GITHUB_TOKEN, CIRCLE_PROJECT_USERNAME, CIRCLE_PROJECT_REPONAME, and CIRCLE_TAG (or use --tag) in the environment.
+parameters:
+  binary:
+    type: string
+    description: Path to the binary file to upload
+  asset_name:
+    type: string
+    description: Name for the release asset (e.g. my-orb-mcp-linux-x86_64)
+  tag:
+    type: string
+    description: 'Release tag to publish to (default: $CIRCLE_TAG)'
+    default: ''
+  dry_run:
+    type: boolean
+    description: Describe the upload without performing it
+    default: false
+steps:
+- run:
+    name: publish
+    command: <<include(scripts/publish.sh)>>

--- a/orb/src/commands/save.yml
+++ b/orb/src/commands/save.yml
@@ -1,0 +1,28 @@
+description: 'Stage, commit, and push generated artifacts back to the repository  Idempotent: if the working tree is clean after staging the specified paths, exits successfully without creating an empty commit. The default commit message includes [skip ci] to prevent CI re-triggering.'
+parameters:
+  paths:
+    type: string
+    description: Paths to stage and commit (relative to repository root)
+  message:
+    type: string
+    description: Commit message
+    default: "chore: update generated MCP server artifacts [skip ci]"
+  push:
+    type: enum
+    description: 'Push after committing (default: true)'
+    default: 'true'
+    enum:
+    - 'true'
+    - 'false'
+  no_push:
+    type: boolean
+    description: Stage and commit only, do not push
+    default: false
+  dry_run:
+    type: boolean
+    description: Show what would be committed without writing anything
+    default: false
+steps:
+- run:
+    name: save
+    command: <<include(scripts/save.sh)>>

--- a/orb/src/examples/example.yml
+++ b/orb/src/examples/example.yml
@@ -1,10 +1,10 @@
 description: >
-  Example usage of the gen-orb-mcp orb.
+  Example usage of the ./target/release/gen-orb-mcp orb.
 usage:
   version: 2.1
   orbs:
-    gen-orb-mcp: jerus-org/gen-orb-mcp@1.0
+    ./target/release/gen-orb-mcp: jerus-org/./target/release/gen-orb-mcp@1.0
   workflows:
     use-my-orb:
       jobs:
-        - gen-orb-mcp/generate
+        - ./target/release/gen-orb-mcp/generate

--- a/orb/src/executors/default.yml
+++ b/orb/src/executors/default.yml
@@ -1,6 +1,6 @@
-description: Execution environment with gen-orb-mcp pre-installed.
+description: Execution environment with ./target/release/gen-orb-mcp pre-installed.
 docker:
-- image: jerusdp/gen-orb-mcp:<< parameters.tag >>
+- image: jerusdp/./target/release/gen-orb-mcp:<< parameters.tag >>
 parameters:
   tag:
     type: string

--- a/orb/src/jobs/build.yml
+++ b/orb/src/jobs/build.yml
@@ -1,0 +1,10 @@
+description: Run build command in a dedicated job.
+executor: default
+parameters:
+  input:
+    type: string
+    description: Directory containing generated MCP server source
+steps:
+- checkout
+- build:
+    input: << parameters.input >>

--- a/orb/src/jobs/publish.yml
+++ b/orb/src/jobs/publish.yml
@@ -1,0 +1,24 @@
+description: Run publish command in a dedicated job.
+executor: default
+parameters:
+  binary:
+    type: string
+    description: Path to the binary file to upload
+  asset_name:
+    type: string
+    description: Name for the release asset (e.g. my-orb-mcp-linux-x86_64)
+  tag:
+    type: string
+    description: 'Release tag to publish to (default: $CIRCLE_TAG)'
+    default: ''
+  dry_run:
+    type: boolean
+    description: Describe the upload without performing it
+    default: false
+steps:
+- checkout
+- publish:
+    binary: << parameters.binary >>
+    asset_name: << parameters.asset_name >>
+    tag: << parameters.tag >>
+    dry_run: << parameters.dry_run >>

--- a/orb/src/jobs/save.yml
+++ b/orb/src/jobs/save.yml
@@ -1,0 +1,33 @@
+description: Run save command in a dedicated job.
+executor: default
+parameters:
+  paths:
+    type: string
+    description: Paths to stage and commit (relative to repository root)
+  message:
+    type: string
+    description: Commit message
+    default: "chore: update generated MCP server artifacts [skip ci]"
+  push:
+    type: enum
+    description: 'Push after committing (default: true)'
+    default: 'true'
+    enum:
+    - 'true'
+    - 'false'
+  no_push:
+    type: boolean
+    description: Stage and commit only, do not push
+    default: false
+  dry_run:
+    type: boolean
+    description: Show what would be committed without writing anything
+    default: false
+steps:
+- checkout
+- save:
+    paths: << parameters.paths >>
+    message: << parameters.message >>
+    push: << parameters.push >>
+    no_push: << parameters.no_push >>
+    dry_run: << parameters.dry_run >>

--- a/orb/src/scripts/build.sh
+++ b/orb/src/scripts/build.sh
@@ -1,0 +1,3 @@
+./target/release/gen-orb-mcp build \
+  --input "<< parameters.input >>" \
+  <<# parameters.build_name >>--name "<< parameters.build_name >>"<</ parameters.build_name >>

--- a/orb/src/scripts/diff.sh
+++ b/orb/src/scripts/diff.sh
@@ -1,4 +1,4 @@
-gen-orb-mcp diff \
+./target/release/gen-orb-mcp diff \
   --current "<< parameters.current >>" \
   --previous "<< parameters.previous >>" \
   --since-version "<< parameters.since_version >>" \

--- a/orb/src/scripts/generate.sh
+++ b/orb/src/scripts/generate.sh
@@ -1,4 +1,4 @@
-gen-orb-mcp generate \
+./target/release/gen-orb-mcp generate \
   --orb-path "<< parameters.orb_path >>" \
   <<# parameters.output >>--output "<< parameters.output >>"<</ parameters.output >> \
   <<# parameters.format >>--format "<< parameters.format >>"<</ parameters.format >> \

--- a/orb/src/scripts/migrate.sh
+++ b/orb/src/scripts/migrate.sh
@@ -1,4 +1,4 @@
-gen-orb-mcp migrate \
+./target/release/gen-orb-mcp migrate \
   <<# parameters.ci_dir >>--ci-dir "<< parameters.ci_dir >>"<</ parameters.ci_dir >> \
   --orb "<< parameters.orb >>" \
   --rules "<< parameters.rules >>" \

--- a/orb/src/scripts/prime.sh
+++ b/orb/src/scripts/prime.sh
@@ -1,4 +1,4 @@
-gen-orb-mcp prime \
+./target/release/gen-orb-mcp prime \
   <<# parameters.orb_path >>--orb-path "<< parameters.orb_path >>"<</ parameters.orb_path >> \
   <<# parameters.git_repo >>--git-repo "<< parameters.git_repo >>"<</ parameters.git_repo >> \
   <<# parameters.tag_prefix >>--tag-prefix "<< parameters.tag_prefix >>"<</ parameters.tag_prefix >> \

--- a/orb/src/scripts/publish.sh
+++ b/orb/src/scripts/publish.sh
@@ -1,0 +1,5 @@
+./target/release/gen-orb-mcp publish \
+  --binary "<< parameters.binary >>" \
+  --asset-name "<< parameters.asset_name >>" \
+  <<# parameters.tag >>--tag "<< parameters.tag >>"<</ parameters.tag >> \
+  <<# parameters.dry_run >>--dry-run<</ parameters.dry_run >>

--- a/orb/src/scripts/save.sh
+++ b/orb/src/scripts/save.sh
@@ -1,0 +1,6 @@
+./target/release/gen-orb-mcp save \
+  --paths "<< parameters.paths >>" \
+  <<# parameters.message >>--message "<< parameters.message >>"<</ parameters.message >> \
+  <<# parameters.push >>--push "<< parameters.push >>"<</ parameters.push >> \
+  <<# parameters.no_push >>--no-push<</ parameters.no_push >> \
+  <<# parameters.dry_run >>--dry-run<</ parameters.dry_run >>

--- a/orb/src/scripts/validate.sh
+++ b/orb/src/scripts/validate.sh
@@ -1,2 +1,2 @@
-gen-orb-mcp validate \
+./target/release/gen-orb-mcp validate \
   --orb-path "<< parameters.orb_path >>"


### PR DESCRIPTION
## Summary

- Updates `crates/gen-orb-mcp/README.md` with `build`, `publish`, `save` CLI reference and orb job table; adds complete 5-job workflow example
- Updates `docs/QUICKSTART.md` integrating-into-a-release-pipeline section to show the full orb-based 5-job pipeline
- Updates `docs/CI_INTEGRATION_GUIDE.md` to promote the orb as the recommended approach and update prerequisites (publish requires existing release)
- Updates `docs/ROADMAP.md` to move Tier 2 from planned to completed milestones; adds `build`, `publish`, `save` to the current capabilities table
- Regenerates `orb/src/` via `gen-circleci-orb` to add `build`, `publish`, `save` jobs, commands, and scripts
- Changes `save` CLI `paths` from positional to `--paths` so gen-circleci-orb can parse it correctly (the generated orb now exposes `paths` as a proper parameter)

## Known limitation

The `save` job's `message` parameter default is manually patched in the generated YAML. The `gen-circleci-orb` help parser truncates defaults that contain `[...]` nested inside `[default: ...]`. Tracking issue should be filed against `gen-circleci-orb`.

## Test plan

- [x] `cargo test` — all tests pass including updated `test_cli_parse_save_*` tests
- [x] `cargo clippy --all --tests --all-features -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo audit` — no advisories
- [x] `circleci orb pack orb/src` — packs without errors
- [x] `ls orb/src/jobs/` — shows all 8 jobs (build, diff, generate, migrate, prime, publish, save, validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)