### PR TITLE
fix: remove unused circleci/docker orb from release

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -14,7 +14,6 @@ orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
 
   orb-tools: circleci/orb-tools@12.3.3
-  docker: circleci/docker@3.2.0
 jobs:
   tools:
     executor: toolkit/rust_env_rolling


### PR DESCRIPTION
## Summary

- Removes `docker: circleci/docker@3.2.0` from the `orbs:` section in `.circleci/release.yml`

The `circleci/docker@3.2.0` version does not exist in the orb registry (latest is `3.0.1`), which caused the Release pipeline to fail at config validation. The `build-container` job uses the `docker` CLI directly via `setup_remote_docker` and shell commands — it never references `docker/build` or `docker/push` from the orb, so the orb declaration was unused.

## Test plan

- [x] `docker/` not referenced in any job step in `release.yml`
- Release pipeline should now parse without the "Cannot find circleci/docker@3.2.0" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)