### PR TITLE
fix: break circular dependency in release workflow

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -85,7 +85,7 @@ workflows:
 
       - toolkit/release_crate:
           name: release-gen-orb-mcp
-          requires: [publish-orb-jerus-org]
+          requires: [approve-release]
           package: gen-orb-mcp
           crate_tag_prefix: gen-orb-mcp-v
           build_binary: true


### PR DESCRIPTION
## Summary

Fixes a circular dependency in `.circleci/release.yml` that caused all post-approval jobs to be marked unreachable.

**The cycle:**
```
release-gen-orb-mcp → publish-orb-jerus-org
                             ↑
build-binary-release → build-container
        ↑
release-gen-orb-mcp (cycle closes here)
```

**Fix:** `release-gen-orb-mcp` now requires `[approve-release]` instead of `[publish-orb-jerus-org]`.

**Resulting flow:**
```
tools → calculate-versions → approve-release → release-gen-orb-mcp → build-binary-release
                                                                    ↘ pack-orb-release       → publish-orb-jerus-org
                                                                    ↘ ensure-orb-registered  ↗
                                                                                build-container ↗
                                                                    ↘ toolkit/release_prlog
```

The orb publish happens after the crate release, which is correct — the Docker container executor needs the released binary.

## Test plan

- [x] No `docker/` references remain in the workflow
- [x] Dependency graph is acyclic: `release-gen-orb-mcp` → `approve-release` ← no cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)