### PR TITLE
fix: rewrite orb Dockerfile to install pre-built binary

### DIFF
--- a/orb/Dockerfile
+++ b/orb/Dockerfile
@@ -1,14 +1,13 @@
-FROM rust:1-slim-bookworm AS builder
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates libssl-dev pkg-config \
-    && rm -rf /var/lib/apt/lists/* \
-    && cargo install ./target/release/gen-orb-mcp
-
 FROM debian:12-slim
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates git \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        libssl3 \
+        zlib1g \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -ms /bin/bash circleci
-COPY --from=builder /usr/local/cargo/bin/./target/release/gen-orb-mcp /usr/local/bin/./target/release/gen-orb-mcp
+COPY gen-orb-mcp /usr/local/bin/gen-orb-mcp
+RUN chmod +x /usr/local/bin/gen-orb-mcp
 USER circleci
 WORKDIR /home/circleci/project


### PR DESCRIPTION
## Summary

The `build-container` job was failing because the generated Dockerfile used
`cargo install ./target/release/gen-orb-mcp`, which is invalid — `cargo install`
takes a crate name or `--path <cargo-project>`, not a path to a compiled binary.

The `build-container` CI job copies the pre-built binary into the Docker build context
as `orb/gen-orb-mcp` before running `docker build`. The Dockerfile just needs to `COPY`
that binary into `/usr/local/bin/`.

**Runtime dependencies** (from `ldd` on the release binary):
- `libssl3` / `libcrypto.so.3` — OpenSSL 3.0 (TLS for GitHub API and git)
- `zlib1g` — compression (git pack protocol)
- `libgit2` — statically bundled by the `git2` crate, no system package needed
- `libc6`, `libgcc-s1`, `libm` — always present in `debian:12-slim`

**New Dockerfile:**
```dockerfile
FROM debian:12-slim
RUN apt-get update \
    && apt-get install -y --no-install-recommends ca-certificates git libssl3 zlib1g \
    && rm -rf /var/lib/apt/lists/* \
    && useradd -ms /bin/bash circleci
COPY gen-orb-mcp /usr/local/bin/gen-orb-mcp
RUN chmod +x /usr/local/bin/gen-orb-mcp
USER circleci
WORKDIR /home/circleci/project
```

The generated Dockerfile template in `gen-circleci-orb` also needs fixing — tracked separately.

## Test plan

- [x] `docker build` with a dummy binary in context should succeed
- [x] No `cargo install` invocations remain in the Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)