### PR TITLE
fix: make ensure-orb-registered idempotent on already-exists error

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -45,8 +45,15 @@ jobs:
           name: Ensure orb is registered
           command: |
             circleci setup --token "${CIRCLE_TOKEN}" --host https://circleci.com --no-prompt
-            circleci orb info jerus-org/gen-orb-mcp > /dev/null 2>&1 || \
-              circleci orb create jerus-org/gen-orb-mcp --no-prompt
+            if ! circleci orb info jerus-org/gen-orb-mcp > /dev/null 2>&1; then
+              create_output=$(circleci orb create jerus-org/gen-orb-mcp --no-prompt 2>&1)
+              create_exit=$?
+              echo "${create_output}"
+              if [ "${create_exit}" -ne 0 ] && ! echo "${create_output}" | grep -q "already exists"; then
+                exit "${create_exit}"
+              fi
+            fi
+            echo "Orb is registered."
   build-container:
     docker:
       - image: cimg/base:stable


### PR DESCRIPTION
## Summary

- Fixes release pipeline failure: `circleci orb info` returned non-zero even though `jerus-org/gen-orb-mcp` already exists, causing `circleci orb create` to run and fail with _"an Orb with that name already exists"_
- Replace the `|| \` single-line fallback with an explicit captured-exit-code check that treats the "already exists" message as success while still surfacing genuine failures
- Root cause fix is in `gen-circleci-orb` PR [#44](https://github.com/jerus-org/gen-circleci-orb/pull/44) (generator updated so future `init` runs produce the correct script); this PR fixes the already-generated copy in `release.yml`

## Test plan

- [ ] Re-run the release pipeline — `ensure-orb-registered-jerus-org` step should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)