### PR TITLE
fix: correct docker context and regenerate orb via init

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -14,6 +14,7 @@ orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
 
   orb-tools: circleci/orb-tools@12.3.3
+  docker: circleci/docker@3.2.0
 jobs:
   tools:
     executor: toolkit/rust_env_rolling
@@ -45,8 +46,15 @@ jobs:
           name: Ensure orb is registered
           command: |
             circleci setup --token "${CIRCLE_TOKEN}" --host https://circleci.com --no-prompt
-            circleci orb info jerus-org/gen-orb-mcp > /dev/null 2>&1 || \
-              circleci orb create jerus-org/gen-orb-mcp --no-prompt
+            if ! circleci orb info jerus-org/gen-orb-mcp > /dev/null 2>&1; then
+              create_output=$(circleci orb create jerus-org/gen-orb-mcp --no-prompt 2>&1)
+              create_exit=$?
+              echo "${create_output}"
+              if [ "${create_exit}" -ne 0 ] && ! echo "${create_output}" | grep -q "already exists"; then
+                exit "${create_exit}"
+              fi
+            fi
+            echo "Orb is registered."
   build-container:
     docker:
       - image: cimg/base:stable
@@ -109,7 +117,7 @@ workflows:
           requires: [release-gen-orb-mcp]
       - build-container:
           requires: [build-binary-release]
-          context: [docker-credentials]
+          context: [docker]
       - ensure-orb-registered-jerus-org:
           requires: [release-gen-orb-mcp]
           context: [orb-publishing]

--- a/orb/Dockerfile
+++ b/orb/Dockerfile
@@ -1,13 +1,14 @@
+FROM rust:1-slim-bookworm AS builder
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl-dev pkg-config \
+    && rm -rf /var/lib/apt/lists/* \
+    && cargo install gen-orb-mcp
+
 FROM debian:12-slim
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        git \
-        libssl3 \
-        zlib1g \
+    && apt-get install -y --no-install-recommends ca-certificates git \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -ms /bin/bash circleci
-COPY gen-orb-mcp /usr/local/bin/gen-orb-mcp
-RUN chmod +x /usr/local/bin/gen-orb-mcp
+COPY --from=builder /usr/local/cargo/bin/gen-orb-mcp /usr/local/bin/gen-orb-mcp
 USER circleci
 WORKDIR /home/circleci/project

--- a/orb/src/commands/diff.yml
+++ b/orb/src/commands/diff.yml
@@ -17,3 +17,8 @@ steps:
 - run:
     name: diff
     command: <<include(scripts/diff.sh)>>
+    environment:
+      CURRENT: << parameters.current >>
+      PREVIOUS: << parameters.previous >>
+      SINCE_VERSION: << parameters.since_version >>
+      OUTPUT: << parameters.output >>

--- a/orb/src/commands/generate.yml
+++ b/orb/src/commands/generate.yml
@@ -42,3 +42,13 @@ steps:
 - run:
     name: generate
     command: <<include(scripts/generate.sh)>>
+    environment:
+      ORB_PATH: << parameters.orb_path >>
+      OUTPUT: << parameters.output >>
+      FORMAT: << parameters.format >>
+      GENERATE_NAME: << parameters.generate_name >>
+      VERSION: << parameters.version >>
+      FORCE: << parameters.force >>
+      MIGRATIONS: << parameters.migrations >>
+      PRIOR_VERSIONS: << parameters.prior_versions >>
+      TAG_PREFIX: << parameters.tag_prefix >>

--- a/orb/src/commands/migrate.yml
+++ b/orb/src/commands/migrate.yml
@@ -18,3 +18,8 @@ steps:
 - run:
     name: migrate
     command: <<include(scripts/migrate.sh)>>
+    environment:
+      CI_DIR: << parameters.ci_dir >>
+      ORB: << parameters.orb >>
+      RULES: << parameters.rules >>
+      DRY_RUN: << parameters.dry_run >>

--- a/orb/src/commands/prime.yml
+++ b/orb/src/commands/prime.yml
@@ -44,3 +44,14 @@ steps:
 - run:
     name: prime
     command: <<include(scripts/prime.sh)>>
+    environment:
+      ORB_PATH: << parameters.orb_path >>
+      GIT_REPO: << parameters.git_repo >>
+      TAG_PREFIX: << parameters.tag_prefix >>
+      EARLIEST_VERSION: << parameters.earliest_version >>
+      SINCE: << parameters.since >>
+      PRIOR_VERSIONS_DIR: << parameters.prior_versions_dir >>
+      MIGRATIONS_DIR: << parameters.migrations_dir >>
+      EPHEMERAL: << parameters.ephemeral >>
+      RENAME_MAP: << parameters.rename_map >>
+      DRY_RUN: << parameters.dry_run >>

--- a/orb/src/commands/validate.yml
+++ b/orb/src/commands/validate.yml
@@ -7,3 +7,5 @@ steps:
 - run:
     name: validate
     command: <<include(scripts/validate.sh)>>
+    environment:
+      ORB_PATH: << parameters.orb_path >>

--- a/orb/src/examples/example.yml
+++ b/orb/src/examples/example.yml
@@ -1,10 +1,10 @@
 description: >
-  Example usage of the ./target/release/gen-orb-mcp orb.
+  Example usage of the gen-orb-mcp orb.
 usage:
   version: 2.1
   orbs:
-    ./target/release/gen-orb-mcp: jerus-org/./target/release/gen-orb-mcp@1.0
+    gen-orb-mcp: jerus-org/gen-orb-mcp@1.0
   workflows:
     use-my-orb:
       jobs:
-        - ./target/release/gen-orb-mcp/generate
+        - gen-orb-mcp/generate

--- a/orb/src/executors/default.yml
+++ b/orb/src/executors/default.yml
@@ -1,6 +1,6 @@
-description: Execution environment with ./target/release/gen-orb-mcp pre-installed.
+description: Execution environment with gen-orb-mcp pre-installed.
 docker:
-- image: jerusdp/./target/release/gen-orb-mcp:<< parameters.tag >>
+- image: jerusdp/gen-orb-mcp:<< parameters.tag >>
 parameters:
   tag:
     type: string

--- a/orb/src/scripts/diff.sh
+++ b/orb/src/scripts/diff.sh
@@ -1,5 +1,6 @@
-./target/release/gen-orb-mcp diff \
-  --current "<< parameters.current >>" \
-  --previous "<< parameters.previous >>" \
-  --since-version "<< parameters.since_version >>" \
-  <<# parameters.output >>--output "<< parameters.output >>"<</ parameters.output >>
+set -- gen-orb-mcp diff
+set -- "$@" --current "${CURRENT}"
+set -- "$@" --previous "${PREVIOUS}"
+set -- "$@" --since-version "${SINCE_VERSION}"
+[ -n "${OUTPUT:-}" ] && set -- "$@" --output "${OUTPUT}"
+"$@"

--- a/orb/src/scripts/generate.sh
+++ b/orb/src/scripts/generate.sh
@@ -1,10 +1,11 @@
-./target/release/gen-orb-mcp generate \
-  --orb-path "<< parameters.orb_path >>" \
-  <<# parameters.output >>--output "<< parameters.output >>"<</ parameters.output >> \
-  <<# parameters.format >>--format "<< parameters.format >>"<</ parameters.format >> \
-  <<# parameters.generate_name >>--name "<< parameters.generate_name >>"<</ parameters.generate_name >> \
-  <<# parameters.version >>--version "<< parameters.version >>"<</ parameters.version >> \
-  <<# parameters.force >>--force<</ parameters.force >> \
-  <<# parameters.migrations >>--migrations "<< parameters.migrations >>"<</ parameters.migrations >> \
-  <<# parameters.prior_versions >>--prior-versions "<< parameters.prior_versions >>"<</ parameters.prior_versions >> \
-  <<# parameters.tag_prefix >>--tag-prefix "<< parameters.tag_prefix >>"<</ parameters.tag_prefix >>
+set -- gen-orb-mcp generate
+set -- "$@" --orb-path "${ORB_PATH}"
+[ -n "${OUTPUT:-}" ] && set -- "$@" --output "${OUTPUT}"
+[ -n "${FORMAT:-}" ] && set -- "$@" --format "${FORMAT}"
+[ -n "${GENERATE_NAME:-}" ] && set -- "$@" --name "${GENERATE_NAME}"
+[ -n "${VERSION:-}" ] && set -- "$@" --version "${VERSION}"
+[ "${FORCE:-false}" = "true" ] && set -- "$@" --force
+[ -n "${MIGRATIONS:-}" ] && set -- "$@" --migrations "${MIGRATIONS}"
+[ -n "${PRIOR_VERSIONS:-}" ] && set -- "$@" --prior-versions "${PRIOR_VERSIONS}"
+[ -n "${TAG_PREFIX:-}" ] && set -- "$@" --tag-prefix "${TAG_PREFIX}"
+"$@"

--- a/orb/src/scripts/migrate.sh
+++ b/orb/src/scripts/migrate.sh
@@ -1,5 +1,6 @@
-./target/release/gen-orb-mcp migrate \
-  <<# parameters.ci_dir >>--ci-dir "<< parameters.ci_dir >>"<</ parameters.ci_dir >> \
-  --orb "<< parameters.orb >>" \
-  --rules "<< parameters.rules >>" \
-  <<# parameters.dry_run >>--dry-run<</ parameters.dry_run >>
+set -- gen-orb-mcp migrate
+[ -n "${CI_DIR:-}" ] && set -- "$@" --ci-dir "${CI_DIR}"
+set -- "$@" --orb "${ORB}"
+set -- "$@" --rules "${RULES}"
+[ "${DRY_RUN:-false}" = "true" ] && set -- "$@" --dry-run
+"$@"

--- a/orb/src/scripts/prime.sh
+++ b/orb/src/scripts/prime.sh
@@ -1,11 +1,12 @@
-./target/release/gen-orb-mcp prime \
-  <<# parameters.orb_path >>--orb-path "<< parameters.orb_path >>"<</ parameters.orb_path >> \
-  <<# parameters.git_repo >>--git-repo "<< parameters.git_repo >>"<</ parameters.git_repo >> \
-  <<# parameters.tag_prefix >>--tag-prefix "<< parameters.tag_prefix >>"<</ parameters.tag_prefix >> \
-  <<# parameters.earliest_version >>--earliest-version "<< parameters.earliest_version >>"<</ parameters.earliest_version >> \
-  <<# parameters.since >>--since "<< parameters.since >>"<</ parameters.since >> \
-  <<# parameters.prior_versions_dir >>--prior-versions-dir "<< parameters.prior_versions_dir >>"<</ parameters.prior_versions_dir >> \
-  <<# parameters.migrations_dir >>--migrations-dir "<< parameters.migrations_dir >>"<</ parameters.migrations_dir >> \
-  <<# parameters.ephemeral >>--ephemeral<</ parameters.ephemeral >> \
-  <<# parameters.rename_map >>--rename-map "<< parameters.rename_map >>"<</ parameters.rename_map >> \
-  <<# parameters.dry_run >>--dry-run<</ parameters.dry_run >>
+set -- gen-orb-mcp prime
+[ -n "${ORB_PATH:-}" ] && set -- "$@" --orb-path "${ORB_PATH}"
+[ -n "${GIT_REPO:-}" ] && set -- "$@" --git-repo "${GIT_REPO}"
+[ -n "${TAG_PREFIX:-}" ] && set -- "$@" --tag-prefix "${TAG_PREFIX}"
+[ -n "${EARLIEST_VERSION:-}" ] && set -- "$@" --earliest-version "${EARLIEST_VERSION}"
+[ -n "${SINCE:-}" ] && set -- "$@" --since "${SINCE}"
+[ -n "${PRIOR_VERSIONS_DIR:-}" ] && set -- "$@" --prior-versions-dir "${PRIOR_VERSIONS_DIR}"
+[ -n "${MIGRATIONS_DIR:-}" ] && set -- "$@" --migrations-dir "${MIGRATIONS_DIR}"
+[ "${EPHEMERAL:-false}" = "true" ] && set -- "$@" --ephemeral
+[ -n "${RENAME_MAP:-}" ] && set -- "$@" --rename-map "${RENAME_MAP}"
+[ "${DRY_RUN:-false}" = "true" ] && set -- "$@" --dry-run
+"$@"

--- a/orb/src/scripts/validate.sh
+++ b/orb/src/scripts/validate.sh
@@ -1,2 +1,3 @@
-./target/release/gen-orb-mcp validate \
-  --orb-path "<< parameters.orb_path >>"
+set -- gen-orb-mcp validate
+set -- "$@" --orb-path "${ORB_PATH}"
+"$@"


### PR DESCRIPTION
## Summary

- Root cause of build-container failure: `context: [docker-credentials]` was wrong — the org uses `context: [docker]`
- Re-ran `gen-circleci-orb init --docker-context docker` to regenerate the release pipeline correctly
- Also picks up the idempotent `ensure-orb-registered` script (from gen-circleci-orb v0.0.18) and refreshed orb source from the current installed binary
- The `rewire_release_crate_requires` bug that would have introduced a cycle has been fixed in gen-circleci-orb PR [#45](https://github.com/jerus-org/gen-circleci-orb/pull/45) before this was re-generated

## Test plan

- [ ] Release pipeline re-run — `build-container` step should authenticate and push successfully with `context: [docker]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)