### PR TITLE
fix: correct docker orb version to registry-available 3.0.1

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -14,7 +14,7 @@ orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
 
   orb-tools: circleci/orb-tools@12.3.3
-  docker: circleci/docker@3.2.0
+  docker: circleci/docker@3.0.1
 jobs:
   tools:
     executor: toolkit/rust_env_rolling


### PR DESCRIPTION
## Summary

- `circleci/docker@3.2.0` does not exist in the orb registry — causes `Cannot find circleci/docker@3.2.0 in the orb registry` in the release pipeline
- `3.0.1` is the latest available version (confirmed via `circleci orb list circleci`)
- Root cause fixed upstream in gen-circleci-orb v0.0.21 (PR [#46](https://github.com/jerus-org/gen-circleci-orb/pull/46))

## Test plan

- [ ] Release pipeline should proceed past the orb-loading stage without the registry error

🤖 Generated with [Claude Code](https://claude.com/claude-code)