### PR TITLE
fix: handle circleci setup exit 255 in ensure-orb-registered

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -45,7 +45,13 @@ jobs:
       - run:
           name: Ensure orb is registered
           command: |
-            circleci setup --token "${CIRCLE_TOKEN}" --host https://circleci.com --no-prompt
+            setup_exit=0
+            setup_output=$(circleci setup --token "${CIRCLE_TOKEN}" --host https://circleci.com --no-prompt 2>&1) || setup_exit=$?
+            echo "${setup_output}"
+            if [ "${setup_exit}" -ne 0 ] && ! echo "${setup_output}" | grep -q "Setup complete"; then
+              echo "circleci setup failed with exit ${setup_exit}" >&2
+              exit "${setup_exit}"
+            fi
             if ! circleci orb info jerus-org/gen-orb-mcp > /dev/null 2>&1; then
               create_output=$(circleci orb create jerus-org/gen-orb-mcp --no-prompt 2>&1)
               create_exit=$?


### PR DESCRIPTION
## Summary

- `circleci setup --no-prompt` in newer CLI versions (orb-tools/default executor) exits 255 even when setup succeeds ("Setup complete." is printed)
- With `#!/bin/bash -eo pipefail`, this killed the script at the setup line — all subsequent orb commands never ran
- Root cause of the `ensure-orb-registered-jerus-org` failure at exit code 255 seen in Release #702

## Fix

Replace bare `circleci setup` with a pattern that captures exit code and checks output:
- Fails only if exit is non-zero AND output does **not** contain `"Setup complete"` — genuine failures (bad token, network) still surface
- Tolerates the known 255 quirk when setup visibly completed

Fix generated from gen-circleci-orb v0.0.22 (PR [#50](https://github.com/jerus-org/gen-circleci-orb/pull/50)).

## Test plan

- [ ] Release pipeline — `ensure-orb-registered-jerus-org` should pass through the setup step

🤖 Generated with [Claude Code](https://claude.com/claude-code)