### PR TITLE
fix: use set +e to tolerate circleci setup exit 255

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -45,10 +45,11 @@ jobs:
       - run:
           name: Ensure orb is registered
           command: |
-            setup_exit=0
-            setup_output=$(circleci setup --token "${CIRCLE_TOKEN}" --host https://circleci.com --no-prompt 2>&1) || setup_exit=$?
-            echo "${setup_output}"
-            if [ "${setup_exit}" -ne 0 ] && ! echo "${setup_output}" | grep -q "Setup complete"; then
+            set +e
+            circleci setup --token "${CIRCLE_TOKEN}" --host https://circleci.com --no-prompt
+            setup_exit=$?
+            set -e
+            if [ "${setup_exit}" -ne 0 ] && [ "${setup_exit}" -ne 255 ]; then
               echo "circleci setup failed with exit ${setup_exit}" >&2
               exit "${setup_exit}"
             fi


### PR DESCRIPTION
## Why the previous fix (#127) didn't work

PR #127 tried to capture `circleci setup` output with `$(... 2>&1)` and check for "Setup complete" in the captured string. This failed because the CLI writes directly to `/dev/tty` (not stdout/stderr), so the capture produces an empty string. The grep check never matches, and the script still exits 255.

## This fix

Use `set +e` / `set -e` to run the command directly (output goes to the terminal as intended) and check the exit code numerically:

```bash
set +e
circleci setup --token "${CIRCLE_TOKEN}" --host https://circleci.com --no-prompt
setup_exit=$?
set -e
if [ "${setup_exit}" -ne 0 ] && [ "${setup_exit}" -ne 255 ]; then
  echo "circleci setup failed with exit ${setup_exit}" >&2
  exit "${setup_exit}"
fi
```

**Not burying errors:** only exit code `255` is tolerated — this is the specific known quirk. Any other non-zero exit (wrong token, unreachable host, etc.) still fails the job immediately.

## Note

Once validated, the same pattern will be applied in the gen-circleci-orb generator so future `init` runs produce the correct script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)