### PR TITLE
fix: accept exit 255 from circleci orb info as registered

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -53,9 +53,16 @@ jobs:
               echo "circleci setup failed with exit ${setup_exit}" >&2
               exit "${setup_exit}"
             fi
-            if ! circleci orb info jerus-org/gen-orb-mcp > /dev/null 2>&1; then
+            set +e
+            circleci orb info jerus-org/gen-orb-mcp
+            orb_info_exit=$?
+            set -e
+            echo "orb info exit: ${orb_info_exit}"
+            if [ "${orb_info_exit}" -ne 0 ] && [ "${orb_info_exit}" -ne 255 ]; then
+              set +e
               create_output=$(circleci orb create jerus-org/gen-orb-mcp --no-prompt 2>&1)
               create_exit=$?
+              set -e
               echo "${create_output}"
               if [ "${create_exit}" -ne 0 ] && ! echo "${create_output}" | grep -q "already exists"; then
                 exit "${create_exit}"


### PR DESCRIPTION
## Problem

The newer CircleCI CLI in the `orb-tools/default` executor returns exit 255 from both `circleci setup` (fixed in PR #128) and `circleci orb info`, even when the orb is registered and has published versions.

The old script used `if ! circleci orb info ... > /dev/null 2>&1` — any non-zero exit entered the create block. With exit 255 from `orb info`, the script attempted `circleci orb create` on every run against an already-registered orb.

## Fix

- Use `set +e` / `set -e` around `circleci orb info` to capture the exit code
- Only enter the create block if exit is non-zero **and not 255** (255 = known quirk, orb exists)
- Remove the `> /dev/null 2>&1` redirect so orb info output is visible in CI logs

## Diagnostic output

`echo "orb info exit: ${orb_info_exit}"` is included so the CI log confirms what exit code the CLI is returning in this environment.

## Next step

Once confirmed working, the same pattern (`set +e` / exit-255 tolerance) will be applied to the gen-circleci-orb generator for all future `init` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)