### PR TITLE
fix: halt container build and orb publish when no crate version

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -84,6 +84,10 @@ jobs:
           command: |
             source /tmp/release-versions/versions.env
             VERSION=${CRATE_VERSION_GEN_ORB_MCP}
+            if [ "${VERSION}" = "none" ] || [ -z "${VERSION}" ]; then
+              echo "No crate version calculated. Skipping container build."
+              circleci-agent step halt
+            fi
             cp /tmp/bin/gen-orb-mcp orb/gen-orb-mcp
             docker build -t jerusdp/gen-orb-mcp:${VERSION} -t jerusdp/gen-orb-mcp:latest orb
             echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
@@ -144,6 +148,10 @@ workflows:
                 name: Export orb version as CIRCLE_TAG
                 command: |
                   source /tmp/release-versions/versions.env
+                  if [ "${CRATE_VERSION_GEN_ORB_MCP}" = "none" ] || [ -z "${CRATE_VERSION_GEN_ORB_MCP}" ]; then
+                    echo "No crate version calculated. Skipping orb publish."
+                    circleci-agent step halt
+                  fi
                   echo "export CIRCLE_TAG=v${CRATE_VERSION_GEN_ORB_MCP}" >> "$BASH_ENV"
           orb_name: jerus-org/gen-orb-mcp
           pub_type: production


### PR DESCRIPTION
## Summary

- When nextsv returns `none` (CI-only changes with no Rust code bump), `build-container` was building `jerusdp/gen-orb-mcp:none` and `orb-tools/publish` was failing with **"Malformed tag detected: Tag: vnone"** (exit 1)
- Root cause: `CRATE_VERSION_GEN_ORB_MCP=none` from `calculate_versions` propagates through to both downstream jobs without a guard
- Fix: add `circleci-agent step halt` guards in `build-container` (before the Docker build) and in the `orb-tools/publish` pre-step (before exporting `CIRCLE_TAG`)

## Test plan

- [ ] Merge and trigger a release pipeline with no crate version override — `build-container` and `publish-orb-jerus-org` should halt successfully (not fail)
- [ ] Trigger a release pipeline with `gen_orb_mcp_version=0.1.12` override — both steps should run and complete normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)