### PR TITLE
fix: exit 0 after step halt to stop script execution

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -87,6 +87,7 @@ jobs:
             if [ "${VERSION}" = "none" ] || [ -z "${VERSION}" ]; then
               echo "No crate version calculated. Skipping container build."
               circleci-agent step halt
+              exit 0
             fi
             cp /tmp/bin/gen-orb-mcp orb/gen-orb-mcp
             docker build -t jerusdp/gen-orb-mcp:${VERSION} -t jerusdp/gen-orb-mcp:latest orb
@@ -151,6 +152,7 @@ workflows:
                   if [ "${CRATE_VERSION_GEN_ORB_MCP}" = "none" ] || [ -z "${CRATE_VERSION_GEN_ORB_MCP}" ]; then
                     echo "No crate version calculated. Skipping orb publish."
                     circleci-agent step halt
+                    exit 0
                   fi
                   echo "export CIRCLE_TAG=v${CRATE_VERSION_GEN_ORB_MCP}" >> "$BASH_ENV"
           orb_name: jerus-org/gen-orb-mcp


### PR DESCRIPTION
## Summary

- `circleci-agent step halt` signals the CircleCI agent that the job should be marked successful, but **does not exit the bash script** — execution continues past the `if` block
- In Release #730, the "No crate version calculated." message printed, then the Docker build ran anyway (1m 49s, pulled all layers, started `cargo install gen-orb-mcp`)
- Fix: add `exit 0` immediately after `circleci-agent step halt` in both guards (`build-container` and `orb-tools/publish` pre-step)

## Test plan

- [ ] Merge and trigger release pipeline without version override — `build-container` step should print "No crate version calculated." and stop immediately; orb publish step should halt and not call the publishing step

🤖 Generated with [Claude Code](https://claude.com/claude-code)