### PR TITLE
feat: add gate-orb-release job as single decision point

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -28,6 +28,22 @@ jobs:
             cargo release --version
             rsign --version
 
+  gate-orb-release:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - attach_workspace:
+          at: /tmp/release-versions
+      - run:
+          name: Check if orb release is required
+          command: |
+            source /tmp/release-versions/versions.env
+            if [ "${CRATE_VERSION_GEN_ORB_MCP}" = "none" ] || [ -z "${CRATE_VERSION_GEN_ORB_MCP}" ]; then
+              echo "No crate version calculated — orb release not required."
+              exit 1
+            fi
+            echo "Orb release required: v${CRATE_VERSION_GEN_ORB_MCP}"
+
   build-binary-release:
     docker:
       - image: rust:latest
@@ -84,11 +100,6 @@ jobs:
           command: |
             source /tmp/release-versions/versions.env
             VERSION=${CRATE_VERSION_GEN_ORB_MCP}
-            if [ "${VERSION}" = "none" ] || [ -z "${VERSION}" ]; then
-              echo "No crate version calculated. Skipping container build."
-              circleci-agent step halt
-              exit 0
-            fi
             cp /tmp/bin/gen-orb-mcp orb/gen-orb-mcp
             docker build -t jerusdp/gen-orb-mcp:${VERSION} -t jerusdp/gen-orb-mcp:latest orb
             echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
@@ -128,17 +139,21 @@ workflows:
             - release
             - bot-check
             - pcu-app
-      - build-binary-release:
+
+      - gate-orb-release:
           requires: [release-gen-orb-mcp]
+
+      - build-binary-release:
+          requires: [gate-orb-release]
       - orb-tools/pack:
           name: pack-orb-release
           source_dir: orb/src
-          requires: [release-gen-orb-mcp]
+          requires: [gate-orb-release]
       - build-container:
           requires: [build-binary-release]
           context: [docker]
       - ensure-orb-registered-jerus-org:
-          requires: [release-gen-orb-mcp]
+          requires: [gate-orb-release]
           context: [orb-publishing]
       - orb-tools/publish:
           name: publish-orb-jerus-org
@@ -149,11 +164,6 @@ workflows:
                 name: Export orb version as CIRCLE_TAG
                 command: |
                   source /tmp/release-versions/versions.env
-                  if [ "${CRATE_VERSION_GEN_ORB_MCP}" = "none" ] || [ -z "${CRATE_VERSION_GEN_ORB_MCP}" ]; then
-                    echo "No crate version calculated. Skipping orb publish."
-                    circleci-agent step halt
-                    exit 0
-                  fi
                   echo "export CIRCLE_TAG=v${CRATE_VERSION_GEN_ORB_MCP}" >> "$BASH_ENV"
           orb_name: jerus-org/gen-orb-mcp
           pub_type: production


### PR DESCRIPTION
## Summary

- Replaces per-job `none`-version guards in `build-container` and `orb-tools/publish` with a single `gate-orb-release` job
- `gate-orb-release` runs after `release-gen-orb-mcp`, reads `versions.env`, and either passes (has version) or fails with a clear message (no version)
- When it fails, all downstream orb-build jobs (`build-binary-release`, `pack-orb-release`, `build-container`, `ensure-orb-registered-jerus-org`, `publish-orb-jerus-org`) are skipped by CircleCI — no Docker pulls, no Rust compile, no registry push
- When it passes, the full orb pipeline runs unchanged

**CircleCI constraint note:** in CircleCI, `circleci-agent step halt` marks a job as *successful* — downstream jobs that require it still run. To actually prevent downstream jobs from executing, the gate must `exit 1`. This means the pipeline shows as failed when there is no orb release to do. That is the honest signal: if the release pipeline was triggered with no Rust code changes, the correct outcome is a fast, informative failure rather than wasted container build time.

## Test plan

- [ ] Trigger release pipeline without version override (CI-only changes) — `gate-orb-release` should fail with "No crate version calculated — orb release not required." and all downstream orb jobs should be skipped
- [ ] Trigger release pipeline with `gen_orb_mcp_version=0.1.12` — `gate-orb-release` should pass and full orb pipeline should complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)