### PR TITLE
fix: match orb-tools workspace contract in orb-release-pack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,20 @@ jobs:
             cat orb/src/executors/default.yml
       - run:
           name: Pack orb
-          command: circleci orb pack orb/src > orb.yml
+          command: |
+            mkdir -p dist
+            circleci orb pack --skip-update-check orb/src > dist/orb.yml
+      - run:
+          name: Create workspace tarball
+          command: |
+            TMP=$(mktemp -d)
+            tar -czf "${TMP}/orb_source.tar.gz" -C dist .
+            rm -rf dist
+            mkdir -p dist
+            mv "${TMP}/orb_source.tar.gz" dist/orb_source.tar.gz
       - persist_to_workspace:
           root: .
-          paths: [orb.yml]
+          paths: [dist/orb_source.tar.gz]
 
   orb-release-container:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,35 +23,6 @@ jobs:
           root: target/release
           paths: [gen-orb-mcp]
 
-  orb-release-pack:
-    executor: orb-tools/default
-    steps:
-      - checkout
-      - run:
-          name: Inject release version into executor default tag
-          command: |
-            VERSION=${CIRCLE_TAG#gen-orb-mcp-v}
-            echo "Injecting version: ${VERSION}"
-            sed -i "s/default: latest/default: ${VERSION}/" orb/src/executors/default.yml
-            echo "Updated executor:"
-            cat orb/src/executors/default.yml
-      - run:
-          name: Pack orb
-          command: |
-            mkdir -p dist
-            circleci orb pack --skip-update-check orb/src > dist/orb.yml
-      - run:
-          name: Create workspace tarball
-          command: |
-            TMP=$(mktemp -d)
-            tar -czf "${TMP}/orb_source.tar.gz" -C dist .
-            rm -rf dist
-            mkdir -p dist
-            mv "${TMP}/orb_source.tar.gz" dist/orb_source.tar.gz
-      - persist_to_workspace:
-          root: .
-          paths: [dist/orb_source.tar.gz]
-
   orb-release-container:
     docker:
       - image: cimg/base:stable
@@ -205,7 +176,20 @@ workflows:
             branches:
               ignore: /.*/
 
-      - orb-release-pack:
+      - orb-tools/pack:
+          name: orb-release-pack
+          checkout: false
+          source_dir: orb/src
+          pre-steps:
+            - checkout
+            - run:
+                name: Inject release version into executor default tag
+                command: |
+                  VERSION=${CIRCLE_TAG#gen-orb-mcp-v}
+                  echo "Injecting version: ${VERSION}"
+                  sed -i "s/default: latest/default: ${VERSION}/" orb/src/executors/default.yml
+                  echo "Updated executor:"
+                  cat orb/src/executors/default.yml
           filters:
             tags:
               only: /^gen-orb-mcp-v.*/


### PR DESCRIPTION
## Problem

`orb-tools/publish` fails at "Prep Workspace" with:

```
tar (child): dist/orb_source.tar.gz: Cannot open: No such file or directory
```

`orb-tools/publish` expects `dist/orb_source.tar.gz` in the workspace — a tarball of the packed orb produced by `orb-tools/pack`. The custom `orb-release-pack` job was producing `orb.yml` at the workspace root, which is the wrong path and format.

## Root cause

Read the `orb-tools/pack` job source to understand the exact workspace contract. The pack job does:
1. `mkdir -p dist && circleci orb pack <source_dir> > dist/orb.yml`
2. `tar -czf dist/orb_source.tar.gz -C dist .` (tarballs `dist/` contents)
3. `persist_to_workspace: root: . paths: [dist/orb_source.tar.gz]`

## Fix

Replicate the same sequence in `orb-release-pack` so `orb-tools/publish` finds the workspace artifact it expects.

## Test plan

- [ ] Rerun the `orb-release` workflow via a coerced release; `publish-orb` "Prep Workspace" step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)