### PR TITLE
fix(orb): use gen-orb-mcp from PATH in scripts

### DIFF
--- a/orb/src/scripts/build.sh
+++ b/orb/src/scripts/build.sh
@@ -1,3 +1,3 @@
-./target/release/gen-orb-mcp build \
+gen-orb-mcp build \
   --input "<< parameters.input >>" \
   <<# parameters.build_name >>--name "<< parameters.build_name >>"<</ parameters.build_name >>

--- a/orb/src/scripts/publish.sh
+++ b/orb/src/scripts/publish.sh
@@ -1,4 +1,4 @@
-./target/release/gen-orb-mcp publish \
+gen-orb-mcp publish \
   --binary "<< parameters.binary >>" \
   --asset-name "<< parameters.asset_name >>" \
   <<# parameters.tag >>--tag "<< parameters.tag >>"<</ parameters.tag >> \

--- a/orb/src/scripts/save.sh
+++ b/orb/src/scripts/save.sh
@@ -1,4 +1,4 @@
-./target/release/gen-orb-mcp save \
+gen-orb-mcp save \
   --paths "<< parameters.paths >>" \
   <<# parameters.message >>--message "<< parameters.message >>"<</ parameters.message >> \
   <<# parameters.push >>--push "<< parameters.push >>"<</ parameters.push >> \


### PR DESCRIPTION
## Summary

- `build.sh`, `save.sh`, and `publish.sh` were invoking `./target/release/gen-orb-mcp`, a cargo build-artifact path that does not exist in the `jerusdp/gen-orb-mcp` Docker executor
- The binary is pre-installed at `/usr/local/bin/gen-orb-mcp` and available on `PATH`, matching the pattern already used by `generate.sh`
- Fix: replace the hardcoded relative path with the bare command name in all three scripts

## Test plan

- [ ] Orb packs without errors
- [ ] CI validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)