### PR TITLE
fix: use rust:slim base so build and format:binary work

### DIFF
--- a/orb/Dockerfile
+++ b/orb/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12-slim
+FROM rust:slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates git \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary

- Change `orb/Dockerfile` base from `debian:12-slim` to `rust:slim`
- `rust:slim` includes `cargo` and `rustc` so `gen-orb-mcp build` and `gen-orb-mcp generate --format binary` now work in the orb's default executor

## Root cause

The `jerusdp/gen-orb-mcp` image had no Rust toolchain. Both `gen-orb-mcp build` and the `format: binary` path in `gen-orb-mcp generate` call `std::process::Command::new("cargo")` internally, failing with `No such file or directory`.

## Test plan

- [ ] Build image locally: `docker build -t test-gen-orb-mcp orb/` after copying a gen-orb-mcp binary
- [ ] Confirm `docker run test-gen-orb-mcp cargo --version` succeeds
- [ ] Confirm existing gen-orb-mcp commands (prime, generate --format source, validate) still work

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)