### PR TITLE
feat(ci): add build-mcp-server to orb-release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,52 @@ jobs:
             docker push jerusdp/gen-orb-mcp:${VERSION}
             docker push jerusdp/gen-orb-mcp:latest
 
+  build-mcp-server:
+    docker:
+      - image: jerusdp/gen-orb-mcp:latest
+    steps:
+      - checkout
+      - run:
+          name: Set up git and environment
+          command: |
+            VERSION=${CIRCLE_TAG#gen-orb-mcp-v}
+            echo "export VERSION=${VERSION}" >> "$BASH_ENV"
+            echo "export CIRCLE_BRANCH=main" >> "$BASH_ENV"
+            git fetch origin main
+            git checkout -B main origin/main
+      - run:
+          name: Prime prior versions and migrations
+          command: |
+            gen-orb-mcp prime \
+              --orb-path orb/src/@orb.yml \
+              --tag-prefix v
+      - run:
+          name: Generate and compile MCP server
+          command: |
+            gen-orb-mcp generate \
+              --format binary \
+              --name gen-orb-mcp \
+              --orb-path orb/src/@orb.yml \
+              --output /tmp/mcp-server \
+              --version "${VERSION}" \
+              --force \
+              --prior-versions prior-versions \
+              --migrations migrations
+      - run:
+          name: Publish MCP server binary to GitHub release
+          command: |
+            gen-orb-mcp publish \
+              --binary /tmp/mcp-server/target/release/gen_orb_mcp_mcp \
+              --asset-name gen_orb_mcp_mcp-linux-x86_64 \
+              --tag "${CIRCLE_TAG}"
+      - run:
+          name: Commit back generated artifacts
+          command: |
+            gen-orb-mcp save \
+              --paths prior-versions \
+              --paths migrations \
+              --sign
+
   orb-release-ensure-registered:
     executor: orb-tools/default
     steps:
@@ -227,6 +273,17 @@ workflows:
           enable_pr_comment: false
           requires: [orb-release-container, orb-release-pack, orb-release-ensure-registered]
           context: [orb-publishing]
+          filters:
+            tags:
+              only: /^gen-orb-mcp-v.*/
+            branches:
+              ignore: /.*/
+
+      - build-mcp-server:
+          requires: [publish-orb]
+          context:
+            - release
+            - bot-check
           filters:
             tags:
               only: /^gen-orb-mcp-v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,7 @@ workflows:
           context:
             - release
             - bot-check
+            - pcu-app
           filters:
             tags:
               only: /^gen-orb-mcp-v.*/


### PR DESCRIPTION
## Summary

- Adds `build-mcp-server` job to the `orb-release` workflow in `config.yml`
- Runs after `publish-orb` using the `jerusdp/gen-orb-mcp:latest` executor (the image just built by `orb-release-container`)
- Completes the dogfooding loop: gen-orb-mcp generates and ships its own MCP server as part of every crate release

## What the job does

1. **Set up**: extracts `VERSION` from `CIRCLE_TAG`, exports `CIRCLE_BRANCH=main` (tag pipelines don't set it), fetches and checks out `main` (detached HEAD after `checkout` in a tag pipeline)
2. **Prime**: runs `gen-orb-mcp prime --orb-path orb/src/@orb.yml --tag-prefix v` to populate `prior-versions/` and `migrations/` from git tag history
3. **Generate**: runs `gen-orb-mcp generate --format binary --name gen-orb-mcp ...` to compile the MCP server binary (`gen_orb_mcp_mcp`)
4. **Publish**: uploads `gen_orb_mcp_mcp-linux-x86_64` to the existing GitHub release for `${CIRCLE_TAG}`
5. **Commit back**: runs `gen-orb-mcp save --paths prior-versions --paths migrations --sign` to GPG-sign commit and push via GitHub App token

## Design notes

- Uses `jerusdp/gen-orb-mcp:latest` (static image tag) — safe because this job `requires: [publish-orb]` which `requires: [orb-release-container]`, so `latest` is already the just-released version
- `CIRCLE_BRANCH=main` override is required — pcu's `push_commit` reads this to find the local branch to push; tag pipelines don't set it
- `git checkout -B main origin/main` is required — `checkout` in a tag pipeline leaves the repo in detached HEAD; git2's `find_branch("main", Local)` needs a local branch
- Contexts: `release` (GITHUB_TOKEN for publish + push), `bot-check` (BOT_GPG_KEY/BOT_TRUST/BOT_USER_NAME/BOT_USER_EMAIL/BOT_SIGN_KEY for signed commit)

## Test plan

- [ ] Merge this PR and the next crate release will exercise the full pipeline
- [ ] Verify `gen_orb_mcp_mcp-linux-x86_64` appears as a release asset after the next `gen-orb-mcp-v*` tag
- [ ] Verify `prior-versions/` and `migrations/` are updated in a GPG-signed commit on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)