### PR TITLE
fix: add openssh-client to executor Dockerfile

### DIFF
--- a/orb/Dockerfile
+++ b/orb/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:slim
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates git gnupg \
+    && apt-get install -y --no-install-recommends ca-certificates git gnupg openssh-client \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -ms /bin/bash circleci
 COPY gen-orb-mcp /usr/local/bin/gen-orb-mcp


### PR DESCRIPTION
## Summary

- Add `openssh-client` to the `apt-get install` line in `orb/Dockerfile`

## Problem

The `build-mcp-server` job (pipeline #806) failed at "Set up git and environment" with:

```
error: cannot run ssh: No such file or directory
fatal: unable to fork
exit code 128
```

CircleCI's `checkout` step configures `GIT_SSH_COMMAND` and the SSH agent, so subsequent `git fetch origin main` tries to invoke the `ssh` binary. `rust:slim` does not include `openssh-client`, so `ssh` is not found.

## Fix

Adding `openssh-client` to the executor image gives git the `ssh` binary it needs.

## Test plan

- [ ] PR merges and CI builds a new `jerusdp/gen-orb-mcp` image
- [ ] Next `gen-orb-mcp-v*` tag triggers `orb-release` → `build-mcp-server` passes "Set up git and environment"

🤖 Generated with [Claude Code](https://claude.com/claude-code)