### PR TITLE
fix: use uploads.github.com base URL for release asset upload

### DIFF
--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -1087,7 +1087,7 @@ async fn upload_release_asset(
     use octocrate::{APIConfig, GitHubAPI, PersonalAccessToken};
 
     let pat = PersonalAccessToken::new(token);
-    let config = APIConfig::with_token(pat).shared();
+    let config = APIConfig::with_token(pat.clone()).shared();
     let api = GitHubAPI::new(&config);
 
     tracing::info!(owner, repo, tag, "Looking up GitHub release");
@@ -1119,7 +1119,12 @@ async fn upload_release_asset(
 
     tracing::info!(asset_name, bytes = file_size, "Uploading asset");
 
-    let result = api
+    // Release asset uploads must go to uploads.github.com, not api.github.com.
+    // octocrate's upload_release_asset requires a separate APIConfig for this base URL.
+    let upload_config = APIConfig::new("https://uploads.github.com", pat);
+    let upload_api = GitHubAPI::new(&upload_config);
+
+    let result = upload_api
         .repos
         .upload_release_asset(owner, repo, release.id)
         .query(&query)


### PR DESCRIPTION
## Summary

- Create a separate `APIConfig` pointed at `https://uploads.github.com` for the `upload_release_asset` call
- The lookup (`get_release_by_tag`) continues to use `api.github.com` as before

## Problem

Pipeline #826 failed at "Publish MCP server binary to GitHub release":

```
Found release release_id=324358898
Uploading asset asset_name="gen_orb_mcp_mcp-linux-x86_64" bytes=4165792
Error: Failed to upload asset 'gen_orb_mcp_mcp-linux-x86_64': Request failed with Error: Not Found
```

octocrate's `upload_release_asset` builds the path `/repos/{owner}/{repo}/releases/{id}/assets`, which when combined with the default `api.github.com` base URL produces the wrong host. GitHub's release asset upload endpoint requires `https://uploads.github.com`. This matches how pcu performs the same operation (line 602 of `pcu/src/cli/release.rs`).

## Test plan

- [ ] Next `gen-orb-mcp-v*` tag triggers `build-mcp-server` and "Publish MCP server binary to GitHub release" passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)