### PR TITLE
fix: use --ignore-garbage and --allow-secret-key-import for GPG import

### DIFF
--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -796,8 +796,13 @@ fn import_gpg_key(b64: &str, trust: &str) -> Result<()> {
     use std::io::Write;
     use std::process::{Command, Stdio};
 
+    // BOT_GPG_KEY is stored in CircleCI with literal \n escape sequences.
+    // --ignore-garbage absorbs them; --allow-secret-key-import is required for private keys.
     let mut cmd = Command::new("sh")
-        .args(["-c", "base64 -d | gpg --batch --import"])
+        .args([
+            "-c",
+            "base64 --decode --ignore-garbage | gpg --batch --allow-secret-key-import --import",
+        ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
## Summary

- Change `base64 -d` to `base64 --decode --ignore-garbage`
- Add `--allow-secret-key-import` to the `gpg --batch --import` call

## Problem

Pipeline #835 failed at "Commit back generated artifacts":

```
Error: gpg key import failed: base64: invalid input
gpg: no valid OpenPGP data found.
gpg: import from '[stdin]' failed: Invalid keyring
```

CircleCI stores `BOT_GPG_KEY` with literal `\n` escape sequences (not real newlines). `base64 -d` rejects these as invalid characters. `--ignore-garbage` absorbs non-base64 characters. `--allow-secret-key-import` is required for private key import.

This matches the toolkit's `import GPG key` step (`orb.yml` line 697):
```bash
echo -e ${BOT_GPG_KEY} \
  | base64 --decode --ignore-garbage \
  | gpg --batch --allow-secret-key-import --import
```

## Test plan

- [ ] Next `gen-orb-mcp-v*` tag triggers `build-mcp-server` and "Commit back generated artifacts" passes GPG import

🤖 Generated with [Claude Code](https://claude.com/claude-code)