### PR TITLE
fix: expand \n sequences in BOT_TRUST before ownertrust import

### DIFF
--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -827,7 +827,9 @@ fn import_gpg_key(b64: &str, trust: &str) -> Result<()> {
         .spawn()
         .map_err(|e| anyhow::anyhow!("Failed to spawn gpg --import-ownertrust: {}", e))?;
     if let Some(mut stdin) = trust_cmd.stdin.take() {
-        stdin.write_all(trust.as_bytes())?;
+        // BOT_TRUST is stored in CircleCI with literal \n escape sequences.
+        let trust_expanded = trust.replace("\\n", "\n");
+        stdin.write_all(trust_expanded.as_bytes())?;
     }
     let trust_out = trust_cmd.wait_with_output()?;
     if !trust_out.status.success() {


### PR DESCRIPTION
## Summary

- Replace literal `\n` escape sequences with real newlines in `BOT_TRUST` before piping to `gpg --import-ownertrust`

## Problem

Pipeline #843 failed at "Commit back generated artifacts":

```
Error: gpg ownertrust import failed: gpg: error in '[stdin]': line too long
```

CircleCI stores `BOT_TRUST` with literal `\n` escape sequences (same as `BOT_GPG_KEY`). When the raw value is piped directly to `gpg --import-ownertrust`, gpg sees one very long line and rejects it. The GPG key import was fixed in #145 with `--ignore-garbage`; the ownertrust value requires actual newlines so we expand them in Rust before writing to stdin.

## Test plan

- [ ] Next `gen-orb-mcp-v*` tag triggers `build-mcp-server` and "Commit back generated artifacts" passes ownertrust import

🤖 Generated with [Claude Code](https://claude.com/claude-code)