### PR TITLE
fix: use shell subprocess for ownertrust import

### DIFF
--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -819,18 +819,26 @@ fn import_gpg_key(b64: &str, trust: &str) -> Result<()> {
         );
     }
 
-    let mut trust_cmd = Command::new("gpg")
-        .args(["--import-ownertrust"])
-        .stdin(Stdio::piped())
+    // Diagnostic: log trust value metadata so CI failures are interpretable.
+    eprintln!(
+        "BOT_TRUST: len={}, has_real_newline={}, has_escape_newline={}",
+        trust.len(),
+        trust.contains('\n'),
+        trust.contains("\\n")
+    );
+
+    // Replicate toolkit behavior exactly:
+    //   echo ${BOT_TRUST} | gpg --import-ownertrust
+    // Pass the value via env var to avoid shell injection, use quoted echo so
+    // word-splitting doesn't corrupt the fingerprint, and let echo append the
+    // trailing newline that gpg's line parser requires.
+    let trust_cmd = Command::new("sh")
+        .args(["-c", "echo \"$_GPG_TRUST\" | gpg --import-ownertrust"])
+        .env("_GPG_TRUST", trust)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| anyhow::anyhow!("Failed to spawn gpg --import-ownertrust: {}", e))?;
-    if let Some(mut stdin) = trust_cmd.stdin.take() {
-        // BOT_TRUST is stored in CircleCI with literal \n escape sequences.
-        let trust_expanded = trust.replace("\\n", "\n");
-        stdin.write_all(trust_expanded.as_bytes())?;
-    }
+        .map_err(|e| anyhow::anyhow!("Failed to spawn ownertrust import: {}", e))?;
     let trust_out = trust_cmd.wait_with_output()?;
     if !trust_out.status.success() {
         anyhow::bail!(


### PR DESCRIPTION
## Summary

- Replaces direct `gpg --import-ownertrust` pipe with a shell subprocess: `echo "$_GPG_TRUST" | gpg --import-ownertrust`
- This replicates the toolkit's exact approach (`echo ${BOT_TRUST} | gpg --import-ownertrust`) — the `echo` provides the trailing newline gpg's line parser requires, and handles the value naturally
- Value is passed via env var (`_GPG_TRUST`) to avoid shell injection; uses quoted echo to prevent word-splitting on the fingerprint
- Removes the `replace("\\n", "\n")` approach from PR #146 which did not resolve the "line too long" error in pipeline #852
- Adds diagnostic `eprintln!` logging: prints length and newline characteristics of `BOT_TRUST` so if the import still fails the CI log will show exactly what the value looks like

## Background

Pipeline #852 (gen-orb-mcp-v0.1.21, tag pipeline) failed at `gen-orb-mcp save --sign` with:
```
gpg ownertrust import failed: gpg: error in '[stdin]': line too long
```
The PR #146 fix (`replace("\\n", "\n")`) was deployed but did not resolve the error. The toolkit has always used `echo ${BOT_TRUST} | gpg --import-ownertrust` successfully; this PR aligns our implementation with that approach.

## Test plan

- [ ] Pipeline triggered by new `gen-orb-mcp-v*` tag passes the "Commit back generated artifacts" step
- [ ] CI log shows `BOT_TRUST: len=X, has_real_newline=..., has_escape_newline=...` diagnostic line before the ownertrust import attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)