### PR TITLE
feat: replace hand-rolled ops with pcu library APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1811,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "gen-bsky"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd1a38f1892edb6b6456da1131e2b2bd7dab85db26eafb7a5186f13205cd812"
+checksum = "cfab35874e68bf4a7b48b679b95d83e3b9d69550931eb75e0beafe7de6e3c255"
 dependencies = [
  "aquamarine",
  "base62",
@@ -1833,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "gen-linkedin"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc78badb35e8d9b272cb7908709579bb1c73b69adf48945c0c9e146fc190dc6"
+checksum = "3f5373f612797d078d82d43f6c0f4e943cf8fe5cc15d3955a512bed8aa4d2125"
 dependencies = [
  "chrono",
  "log",
@@ -3657,9 +3657,9 @@ dependencies = [
 
 [[package]]
 name = "pcu"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd56573b30fd04da169c9a295b5ff15af47ec02d9832a93b1b22e63abc34d4f5"
+checksum = "0e1211349a56e76f8c2e208d97a608515b883c16d52c87ef92460b50d962d672"
 dependencies = [
  "base62",
  "base64 0.22.1",
@@ -4089,7 +4089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -4108,7 +4108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5668,9 +5668,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ git2 = "0.20.4"
 git2_credentials = "0.15.0"
 
 # Signed commit and GitHub App token push (for save --sign)
-pcu = "0.6.19"
+pcu = "0.6.20"
 config = { version = "0.15.22", default-features = false }
 
 # Testing

--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -792,64 +792,6 @@ fn read_sign_env() -> Result<SignEnv> {
     })
 }
 
-fn import_gpg_key(b64: &str, trust: &str) -> Result<()> {
-    use std::io::Write;
-    use std::process::{Command, Stdio};
-
-    // BOT_GPG_KEY is stored in CircleCI with literal \n escape sequences.
-    // --ignore-garbage absorbs them; --allow-secret-key-import is required for private keys.
-    let mut cmd = Command::new("sh")
-        .args([
-            "-c",
-            "base64 --decode --ignore-garbage | gpg --batch --allow-secret-key-import --import",
-        ])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| anyhow::anyhow!("Failed to spawn gpg import: {}", e))?;
-    if let Some(mut stdin) = cmd.stdin.take() {
-        stdin.write_all(b64.as_bytes())?;
-    }
-    let out = cmd.wait_with_output()?;
-    if !out.status.success() {
-        anyhow::bail!(
-            "gpg key import failed: {}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-    }
-
-    // Diagnostic: log trust value metadata so CI failures are interpretable.
-    eprintln!(
-        "BOT_TRUST: len={}, has_real_newline={}, has_escape_newline={}",
-        trust.len(),
-        trust.contains('\n'),
-        trust.contains("\\n")
-    );
-
-    // Replicate toolkit behavior exactly:
-    //   echo ${BOT_TRUST} | gpg --import-ownertrust
-    // Pass the value via env var to avoid shell injection, use quoted echo so
-    // word-splitting doesn't corrupt the fingerprint, and let echo append the
-    // trailing newline that gpg's line parser requires.
-    let trust_cmd = Command::new("sh")
-        .args(["-c", "echo \"$_GPG_TRUST\" | gpg --import-ownertrust"])
-        .env("_GPG_TRUST", trust)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| anyhow::anyhow!("Failed to spawn ownertrust import: {}", e))?;
-    let trust_out = trust_cmd.wait_with_output()?;
-    if !trust_out.status.success() {
-        anyhow::bail!(
-            "gpg ownertrust import failed: {}",
-            String::from_utf8_lossy(&trust_out.stderr)
-        );
-    }
-
-    Ok(())
-}
-
 fn setup_git_identity(repo: &git2::Repository, sign_env: &SignEnv) -> Result<()> {
     let mut config = repo.config()?;
     config.set_str("user.name", &sign_env.user_name)?;
@@ -886,22 +828,30 @@ fn run_save(
     sign: bool,
 ) -> Result<()> {
     use git2::Repository;
-
-    let repo = Repository::discover(".")
-        .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
+    use pcu::GitOps as _;
 
     let sign_env_opt = if sign {
         let sign_env = read_sign_env()?;
-        import_gpg_key(&sign_env.gpg_key_b64, &sign_env.gpg_trust)?;
+        pcu::import_gpg_key(&sign_env.gpg_key_b64, &sign_env.gpg_trust)
+            .map_err(|e| anyhow::anyhow!("GPG import failed: {e}"))?;
+        let repo = Repository::discover(".")
+            .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
         setup_git_identity(&repo, &sign_env)?;
         Some(sign_env)
     } else {
         None
     };
 
-    let mut index = repo.index()?;
-    save_stage_paths(&mut index, paths)?;
+    let local_client = pcu::Client::new_local()
+        .map_err(|e| anyhow::anyhow!("Failed to open local git repo: {e}"))?;
+    let path_refs: Vec<&std::path::Path> = paths.iter().map(|p| p.as_path()).collect();
+    local_client
+        .stage_paths(&path_refs)
+        .map_err(|e| anyhow::anyhow!("Failed to stage paths: {e}"))?;
 
+    let repo = Repository::discover(".")
+        .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
+    let mut index = repo.index()?;
     let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
     let diff = save_compute_diff(&repo, &mut index, head_commit.as_ref())?;
 
@@ -951,22 +901,6 @@ fn run_save(
 
         Ok(())
     }
-}
-
-fn save_stage_paths(index: &mut git2::Index, paths: &[std::path::PathBuf]) -> Result<()> {
-    let mut staged_any = false;
-    for path in paths {
-        if path.exists() {
-            index.add_path(path)?;
-            staged_any = true;
-        } else {
-            tracing::warn!(path = %path.display(), "Path does not exist, skipping");
-        }
-    }
-    if staged_any {
-        index.write()?;
-    }
-    Ok(())
 }
 
 fn save_compute_diff<'repo>(
@@ -1053,9 +987,6 @@ fn run_publish(
         anyhow::bail!("Binary not found: {}", binary.display());
     }
 
-    let token = std::env::var("GITHUB_TOKEN")
-        .map_err(|_| anyhow::anyhow!("GITHUB_TOKEN environment variable is not set"))?;
-
     let resolved_tag = match tag {
         Some(t) => t.to_string(),
         None => std::env::var("CIRCLE_TAG").map_err(|_| {
@@ -1063,98 +994,32 @@ fn run_publish(
         })?,
     };
 
-    let owner = std::env::var("CIRCLE_PROJECT_USERNAME").unwrap_or_default();
-    let repo = std::env::var("CIRCLE_PROJECT_REPONAME").unwrap_or_default();
-
     if dry_run {
+        let owner = std::env::var("CIRCLE_PROJECT_USERNAME").unwrap_or_default();
+        let repo_name = std::env::var("CIRCLE_PROJECT_REPONAME").unwrap_or_default();
         println!("Would upload release asset (dry run):");
         println!("  Binary:     {}", binary.display());
         println!("  Asset name: {asset_name}");
         println!("  Tag:        {resolved_tag}");
-        if !owner.is_empty() && !repo.is_empty() {
-            println!("  Repo:       {owner}/{repo}");
+        if !owner.is_empty() && !repo_name.is_empty() {
+            println!("  Repo:       {owner}/{repo_name}");
         }
         return Ok(());
     }
 
+    let pcu_config = build_pcu_config()?;
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?
-        .block_on(upload_release_asset(
-            &token,
-            &owner,
-            &repo,
-            &resolved_tag,
-            binary,
-            asset_name,
-        ))
-}
-
-async fn upload_release_asset(
-    token: &str,
-    owner: &str,
-    repo: &str,
-    tag: &str,
-    binary: &std::path::Path,
-    asset_name: &str,
-) -> Result<()> {
-    use octocrate::repos;
-    use octocrate::{APIConfig, GitHubAPI, PersonalAccessToken};
-
-    let pat = PersonalAccessToken::new(token);
-    let config = APIConfig::with_token(pat.clone()).shared();
-    let api = GitHubAPI::new(&config);
-
-    tracing::info!(owner, repo, tag, "Looking up GitHub release");
-    let release = api
-        .repos
-        .get_release_by_tag(owner, repo, tag)
-        .send()
-        .await
-        .map_err(|e| {
-            anyhow::anyhow!(
-                "Release not found for tag '{}' in {}/{}: {}",
-                tag,
-                owner,
-                repo,
-                e
-            )
-        })?;
-
-    tracing::info!(release_id = release.id, "Found release");
-
-    let file = tokio::fs::File::open(binary)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to open binary '{}': {}", binary.display(), e))?;
-    let file_size = file.metadata().await?.len();
-
-    let query = repos::upload_release_asset::Query::builder()
-        .name(asset_name)
-        .build();
-
-    tracing::info!(asset_name, bytes = file_size, "Uploading asset");
-
-    // Release asset uploads must go to uploads.github.com, not api.github.com.
-    // octocrate's upload_release_asset requires a separate APIConfig for this base URL.
-    let upload_config = APIConfig::new("https://uploads.github.com", pat);
-    let upload_api = GitHubAPI::new(&upload_config);
-
-    let result = upload_api
-        .repos
-        .upload_release_asset(owner, repo, release.id)
-        .query(&query)
-        .header("Content-Type", "application/octet-stream")
-        .header("Content-Length", file_size.to_string())
-        .file(file)
-        .send()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to upload asset '{}': {}", asset_name, e))?;
-
-    println!("Successfully uploaded release asset:");
-    println!("  Asset: {}", result.name);
-    println!("  URL:   {}", result.browser_download_url);
-
-    Ok(())
+        .block_on(async {
+            let client = pcu::Client::new_with(&pcu_config)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to create pcu client: {e}"))?;
+            client
+                .upload_release_asset(&resolved_tag, binary, asset_name)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to upload release asset: {e}"))
+        })
 }
 
 fn run_build(
@@ -2038,18 +1903,16 @@ mod tests {
     }
 
     #[test]
-    fn test_publish_dry_run_with_missing_token_returns_error() {
+    fn test_publish_dry_run_succeeds_without_token() {
         let dir = TempDir::new().unwrap();
         let binary = dir.path().join("my-binary");
         std::fs::write(&binary, b"fake binary").unwrap();
-        // dry_run without GITHUB_TOKEN should fail before attempting any API call
+        // dry_run must succeed without credentials — no API call is made
         std::env::remove_var("GITHUB_TOKEN");
         let result = run_publish(&binary, "my-asset", Some("v1.0.0"), true);
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
         assert!(
-            msg.contains("GITHUB_TOKEN"),
-            "error should mention GITHUB_TOKEN, got: {msg}"
+            result.is_ok(),
+            "dry_run should not require credentials: {result:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- `pcu::import_gpg_key` replaces the local GPG implementation — uses `printf '%b'` for key import (expands CircleCI's literal `\n` sequences) and a **temp file** for `--import-ownertrust`, bypassing gpg's stdin line-length limit that caused the repeated `line too long` pipeline failures in `save --sign`
- `pcu::Client::new_local()` + `stage_paths()` replaces `save_stage_paths`
- `pcu::Client::upload_release_asset()` replaces the local octocrate impl; adds release-lookup retry for GitHub's eventual-consistency window after release creation
- `dry_run` in `run_publish` no longer requires credentials (was an unintentional constraint from placement of the token check before the early-return)

## Root cause of prior `save --sign` failures

All previous fix attempts (`replace("\\n", "\n")`, `echo "$_GPG_TRUST" | gpg --import-ownertrust`) still passed the ownertrust value through a shell pipe, which hits gpg's internal stdin line-length limit. The temp-file approach in `pcu::import_gpg_key` avoids the pipe entirely.

## Test plan

- [ ] CI passes (validation + clippy + tests)
- [ ] Trigger `save --sign` pipeline to confirm `prior-versions/` and `migrations/` are committed back to main

Closes #148 #149 #150 #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)