### PR TITLE
chore(deps): bump pcu to 0.6.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1811,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "gen-bsky"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfab35874e68bf4a7b48b679b95d83e3b9d69550931eb75e0beafe7de6e3c255"
+checksum = "4674d6ef3f3dd96889ca1c271a56edc61fb71383c6c51aa88d6d8a128db0431c"
 dependencies = [
  "aquamarine",
  "base62",
@@ -1833,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "gen-linkedin"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5373f612797d078d82d43f6c0f4e943cf8fe5cc15d3955a512bed8aa4d2125"
+checksum = "4ed088dddf48da6921326556c48280f780a85bbb501b652de0d3d42b53028d75"
 dependencies = [
  "chrono",
  "log",
@@ -3657,9 +3657,9 @@ dependencies = [
 
 [[package]]
 name = "pcu"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1211349a56e76f8c2e208d97a608515b883c16d52c87ef92460b50d962d672"
+checksum = "b71dca4e37799eae44256c07379a4a7cf5ad900d39d55d781795a3a3718ed990"
 dependencies = [
  "base62",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ git2 = "0.20.4"
 git2_credentials = "0.15.0"
 
 # Signed commit and GitHub App token push (for save --sign)
-pcu = "0.6.20"
+pcu = "0.6.21"
 config = { version = "0.15.22", default-features = false }
 
 # Testing


### PR DESCRIPTION
## Summary

- Bumps `pcu` from `0.6.20` to `0.6.21`
- pcu 0.6.21 fixes `stage_paths` to handle directory paths using `add_all` instead of `add_path` (jerus-org/pcu#960)
- No gen-orb-mcp code changes required — `run_save` already uses inline `add_all` directly

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy --all --tests --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo audit` — both active advisories (RUSTSEC-2023-0071, RUSTSEC-2024-0370) remain suppressed in `.cargo/audit.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)