### PR TITLE
fix(save): restore client.stage_paths + fix stale container binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,16 @@ jobs:
       - image: jerusdp/gen-orb-mcp:latest
     steps:
       - checkout
+      - attach_workspace:
+          at: /tmp/bin
       - run:
           name: Set up git and environment
           command: |
+            # Use the freshly built binary from this pipeline's orb-release-binary
+            # job. The Docker image provides system deps (git, gnupg, openssh) but
+            # may have a cached older binary — always prefer the workspace artifact.
+            chmod +x /tmp/bin/gen-orb-mcp
+            echo 'export PATH=/tmp/bin:$PATH' >> "$BASH_ENV"
             VERSION=${CIRCLE_TAG#gen-orb-mcp-v}
             echo "export VERSION=${VERSION}" >> "$BASH_ENV"
             echo "export CIRCLE_BRANCH=main" >> "$BASH_ENV"

--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -841,55 +841,77 @@ fn run_save(
         None
     };
 
-    // Use add_all (not add_path) so directory paths like "prior-versions/" are
-    // staged recursively — git2::Index::add_path cannot handle directories.
-    let repo = Repository::discover(".")
-        .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
-    let mut index = repo.index()?;
-    let path_strs: Vec<&str> = paths.iter().filter_map(|p| p.to_str()).collect();
-    index
-        .add_all(path_strs.iter(), git2::IndexAddOption::DEFAULT, None)
-        .map_err(|e| anyhow::anyhow!("Failed to stage paths: {e}"))?;
-    index.write()?;
-    let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
-    let diff = save_compute_diff(&repo, &mut index, head_commit.as_ref())?;
-
-    if diff.deltas().count() == 0 {
-        println!("Nothing to commit — working tree clean after staging.");
-        return Ok(());
-    }
-
-    if dry_run {
-        save_print_dry_run(&diff, message, push);
-        return Ok(());
-    }
-
     if let Some(_sign_env) = sign_env_opt {
+        // Signing path: use pcu library for staging, commit, and push.
+        // pcu::Client::new_with is async; everything else is synchronous.
         let pcu_config = build_pcu_config()?;
-        tokio::runtime::Builder::new_current_thread()
+        let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
-            .build()?
-            .block_on(async {
-                use pcu::GitOps;
-                let client = pcu::Client::new_with(&pcu_config)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to create pcu client: {}", e))?;
-                let sign_config = pcu::SignConfig::new(pcu::Sign::Gpg);
-                client
-                    .commit_staged(sign_config, message, "", None)
-                    .map_err(|e| anyhow::anyhow!("Failed to sign and commit: {}", e))?;
-                println!("Created signed commit: {message}");
-                if push {
-                    let bot_name =
-                        std::env::var("BOT_USER_NAME").unwrap_or_else(|_| "bot".to_string());
-                    client
-                        .push_commit("", None, false, &bot_name)
-                        .map_err(|e| anyhow::anyhow!("Failed to push: {}", e))?;
-                    println!("Pushed to remote.");
-                }
-                Ok(())
-            })
+            .build()?;
+        let client = rt
+            .block_on(pcu::Client::new_with(&pcu_config))
+            .map_err(|e| anyhow::anyhow!("Failed to create pcu client: {}", e))?;
+
+        use pcu::GitOps;
+        let path_refs: Vec<&std::path::Path> = paths.iter().map(|p| p.as_path()).collect();
+        client
+            .stage_paths(&path_refs)
+            .map_err(|e| anyhow::anyhow!("Failed to stage paths: {e}"))?;
+
+        // Open a fresh repo handle after staging so the index reflects the
+        // changes written to disk by client.stage_paths().
+        let repo = Repository::discover(".")
+            .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
+        let mut index = repo.index()?;
+        let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
+        let diff = save_compute_diff(&repo, &mut index, head_commit.as_ref())?;
+
+        if diff.deltas().count() == 0 {
+            println!("Nothing to commit — working tree clean after staging.");
+            return Ok(());
+        }
+
+        if dry_run {
+            save_print_dry_run(&diff, message, push);
+            return Ok(());
+        }
+
+        let sign_config = pcu::SignConfig::new(pcu::Sign::Gpg);
+        client
+            .commit_staged(sign_config, message, "", None)
+            .map_err(|e| anyhow::anyhow!("Failed to sign and commit: {}", e))?;
+        println!("Created signed commit: {message}");
+        if push {
+            let bot_name = std::env::var("BOT_USER_NAME").unwrap_or_else(|_| "bot".to_string());
+            client
+                .push_commit("", None, false, &bot_name)
+                .map_err(|e| anyhow::anyhow!("Failed to push: {}", e))?;
+            println!("Pushed to remote.");
+        }
+        Ok(())
     } else {
+        // Non-signing path: use git2 directly for staging, commit, and push.
+        let repo = Repository::discover(".")
+            .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
+        let mut index = repo.index()?;
+        let path_strs: Vec<&str> = paths.iter().filter_map(|p| p.to_str()).collect();
+        index
+            .add_all(path_strs.iter(), git2::IndexAddOption::DEFAULT, None)
+            .map_err(|e| anyhow::anyhow!("Failed to stage paths: {e}"))?;
+        index.write()?;
+        let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
+        let diff = save_compute_diff(&repo, &mut index, head_commit.as_ref())?;
+
+        if diff.deltas().count() == 0 {
+            println!("Nothing to commit — working tree clean after staging.");
+            return Ok(());
+        }
+
+        if dry_run {
+            save_print_dry_run(&diff, message, push);
+            return Ok(());
+        }
+
         let oid = save_create_commit(&repo, &mut index, message, head_commit.as_ref())?;
         tracing::info!(commit = %oid, "Created commit");
         println!("Created commit {oid}: {message}");

--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -827,101 +827,104 @@ fn run_save(
     dry_run: bool,
     sign: bool,
 ) -> Result<()> {
-    use git2::Repository;
-
-    let sign_env_opt = if sign {
+    if sign {
         let sign_env = read_sign_env()?;
         pcu::import_gpg_key(&sign_env.gpg_key_b64, &sign_env.gpg_trust)
             .map_err(|e| anyhow::anyhow!("GPG import failed: {e}"))?;
-        let repo = Repository::discover(".")
+        let repo = git2::Repository::discover(".")
             .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
         setup_git_identity(&repo, &sign_env)?;
-        Some(sign_env)
+        run_save_signed(paths, message, push, dry_run)
     } else {
-        None
-    };
-
-    if let Some(_sign_env) = sign_env_opt {
-        // Signing path: use pcu library for staging, commit, and push.
-        // pcu::Client::new_with is async; everything else is synchronous.
-        let pcu_config = build_pcu_config()?;
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()?;
-        let client = rt
-            .block_on(pcu::Client::new_with(&pcu_config))
-            .map_err(|e| anyhow::anyhow!("Failed to create pcu client: {}", e))?;
-
-        use pcu::GitOps;
-        let path_refs: Vec<&std::path::Path> = paths.iter().map(|p| p.as_path()).collect();
-        client
-            .stage_paths(&path_refs)
-            .map_err(|e| anyhow::anyhow!("Failed to stage paths: {e}"))?;
-
-        // Open a fresh repo handle after staging so the index reflects the
-        // changes written to disk by client.stage_paths().
-        let repo = Repository::discover(".")
-            .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
-        let mut index = repo.index()?;
-        let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
-        let diff = save_compute_diff(&repo, &mut index, head_commit.as_ref())?;
-
-        if diff.deltas().count() == 0 {
-            println!("Nothing to commit — working tree clean after staging.");
-            return Ok(());
-        }
-
-        if dry_run {
-            save_print_dry_run(&diff, message, push);
-            return Ok(());
-        }
-
-        let sign_config = pcu::SignConfig::new(pcu::Sign::Gpg);
-        client
-            .commit_staged(sign_config, message, "", None)
-            .map_err(|e| anyhow::anyhow!("Failed to sign and commit: {}", e))?;
-        println!("Created signed commit: {message}");
-        if push {
-            let bot_name = std::env::var("BOT_USER_NAME").unwrap_or_else(|_| "bot".to_string());
-            client
-                .push_commit("", None, false, &bot_name)
-                .map_err(|e| anyhow::anyhow!("Failed to push: {}", e))?;
-            println!("Pushed to remote.");
-        }
-        Ok(())
-    } else {
-        // Non-signing path: use git2 directly for staging, commit, and push.
-        let repo = Repository::discover(".")
-            .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
-        let mut index = repo.index()?;
-        let path_strs: Vec<&str> = paths.iter().filter_map(|p| p.to_str()).collect();
-        index
-            .add_all(path_strs.iter(), git2::IndexAddOption::DEFAULT, None)
-            .map_err(|e| anyhow::anyhow!("Failed to stage paths: {e}"))?;
-        index.write()?;
-        let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
-        let diff = save_compute_diff(&repo, &mut index, head_commit.as_ref())?;
-
-        if diff.deltas().count() == 0 {
-            println!("Nothing to commit — working tree clean after staging.");
-            return Ok(());
-        }
-
-        if dry_run {
-            save_print_dry_run(&diff, message, push);
-            return Ok(());
-        }
-
-        let oid = save_create_commit(&repo, &mut index, message, head_commit.as_ref())?;
-        tracing::info!(commit = %oid, "Created commit");
-        println!("Created commit {oid}: {message}");
-
-        if push {
-            save_git_push(&repo)?;
-        }
-
-        Ok(())
+        run_save_unsigned(paths, message, push, dry_run)
     }
+}
+
+fn run_save_signed(
+    paths: &[std::path::PathBuf],
+    message: &str,
+    push: bool,
+    dry_run: bool,
+) -> Result<()> {
+    let pcu_config = build_pcu_config()?;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let client = rt
+        .block_on(pcu::Client::new_with(&pcu_config))
+        .map_err(|e| anyhow::anyhow!("Failed to create pcu client: {}", e))?;
+
+    use pcu::GitOps;
+    let path_refs: Vec<&std::path::Path> = paths.iter().map(|p| p.as_path()).collect();
+    client
+        .stage_paths(&path_refs)
+        .map_err(|e| anyhow::anyhow!("Failed to stage paths: {e}"))?;
+
+    // Open a fresh repo handle after staging so the index reflects the
+    // changes written to disk by client.stage_paths().
+    let repo = git2::Repository::discover(".")
+        .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
+    let mut index = repo.index()?;
+    let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
+    let diff = save_compute_diff(&repo, &mut index, head_commit.as_ref())?;
+
+    if diff.deltas().count() == 0 {
+        println!("Nothing to commit — working tree clean after staging.");
+        return Ok(());
+    }
+    if dry_run {
+        save_print_dry_run(&diff, message, push);
+        return Ok(());
+    }
+
+    let sign_config = pcu::SignConfig::new(pcu::Sign::Gpg);
+    client
+        .commit_staged(sign_config, message, "", None)
+        .map_err(|e| anyhow::anyhow!("Failed to sign and commit: {}", e))?;
+    println!("Created signed commit: {message}");
+    if push {
+        let bot_name = std::env::var("BOT_USER_NAME").unwrap_or_else(|_| "bot".to_string());
+        client
+            .push_commit("", None, false, &bot_name)
+            .map_err(|e| anyhow::anyhow!("Failed to push: {}", e))?;
+        println!("Pushed to remote.");
+    }
+    Ok(())
+}
+
+fn run_save_unsigned(
+    paths: &[std::path::PathBuf],
+    message: &str,
+    push: bool,
+    dry_run: bool,
+) -> Result<()> {
+    let repo = git2::Repository::discover(".")
+        .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
+    let mut index = repo.index()?;
+    let path_strs: Vec<&str> = paths.iter().filter_map(|p| p.to_str()).collect();
+    index
+        .add_all(path_strs.iter(), git2::IndexAddOption::DEFAULT, None)
+        .map_err(|e| anyhow::anyhow!("Failed to stage paths: {e}"))?;
+    index.write()?;
+    let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
+    let diff = save_compute_diff(&repo, &mut index, head_commit.as_ref())?;
+
+    if diff.deltas().count() == 0 {
+        println!("Nothing to commit — working tree clean after staging.");
+        return Ok(());
+    }
+    if dry_run {
+        save_print_dry_run(&diff, message, push);
+        return Ok(());
+    }
+
+    let oid = save_create_commit(&repo, &mut index, message, head_commit.as_ref())?;
+    tracing::info!(commit = %oid, "Created commit");
+    println!("Created commit {oid}: {message}");
+    if push {
+        save_git_push(&repo)?;
+    }
+    Ok(())
 }
 
 fn save_compute_diff<'repo>(


### PR DESCRIPTION
## Summary

- **Root cause**: `build-mcp-server` always ran with the *previous* release's Docker image. CircleCI pulls `jerusdp/gen-orb-mcp:latest` before `orb-release-container` pushes the new image in the same pipeline, so every release ran `gen-orb-mcp save --sign` with the binary from the prior release — never the one just built.
- **CI fix**: add `attach_workspace: at: /tmp/bin` and prepend `/tmp/bin` to `PATH` in `build-mcp-server`. The workspace binary from `orb-release-binary` always takes precedence over whatever is cached in the Docker image.
- **Rust fix**: restore `client.stage_paths()` in the signing path of `run_save`. pcu 0.6.21 fixes the underlying `add_path`→`add_all` bug. The staging is now inside the signing branch; the non-signing branch keeps inline `add_all`.

## What was happening

Pipeline #871 failed:
```
Error: Failed to stage paths: Git2 says: Error { code: -23, klass: 9,
  message: "cannot create blob from '/home/circleci/project/prior-versions': it is a directory" }
```

This was `pcu::stage_paths` using `index.add_path` on a directory (fixed in pcu 0.6.21). But even after the pcu fix was available, the *cached* Docker image meant the pipeline kept running an old binary with the old bug.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — all 218 tests pass including `test_save_directory_path_stages_contents`
- [x] `cargo clippy --all --tests --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] CI: next release should have `build-mcp-server` use `/tmp/bin/gen-orb-mcp`, commit `prior-versions/` and `migrations/` back to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)