### PR TITLE
fix(save): reduce complexity and fix SSH push failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,11 @@ jobs:
             echo "export CIRCLE_BRANCH=main" >> "$BASH_ENV"
             git fetch origin main
             git checkout -B main origin/main
+            # CircleCI checkout clones via SSH (deploy key in agent is read-only).
+            # Switch to HTTPS so pcu's push_commit uses USER_PASS_PLAINTEXT and
+            # the GitHub App token rather than falling back to the SSH deploy key.
+            git remote set-url origin \
+              "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
       - run:
           name: Prime prior versions and migrations
           command: |

--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -883,12 +883,10 @@ fn run_save_signed(
         .map_err(|e| anyhow::anyhow!("Failed to sign and commit: {}", e))?;
     println!("Created signed commit: {message}");
     if push {
-        // Use GITHUB_TOKEN via HTTPS rather than pcu's push_commit, which
-        // falls back to CredentialHandler / SSH agent when USER_PASS_PLAINTEXT
-        // is not offered — picking up the read-only CircleCI deploy key.
-        let repo = git2::Repository::discover(".")
-            .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
-        save_push_with_github_token(&repo)?;
+        let bot_name = std::env::var("BOT_USER_NAME").unwrap_or_else(|_| "bot".to_string());
+        client
+            .push_commit("", None, false, &bot_name)
+            .map_err(|e| anyhow::anyhow!("Failed to push: {}", e))?;
         println!("Pushed to remote.");
     }
     Ok(())
@@ -967,36 +965,6 @@ fn save_create_commit(
     let new_tree = repo.find_tree(new_tree_oid)?;
     let parents: Vec<&git2::Commit> = head_commit.into_iter().collect();
     Ok(repo.commit(Some("HEAD"), &sig, &sig, message, &new_tree, &parents)?)
-}
-
-/// Push the current branch to `origin` using `GITHUB_TOKEN` for HTTPS auth.
-/// Refuses SSH credential types so a read-only deploy key can never be used
-/// as a fallback.
-fn save_push_with_github_token(repo: &git2::Repository) -> Result<()> {
-    let token = std::env::var("GITHUB_TOKEN")
-        .map_err(|_| anyhow::anyhow!("GITHUB_TOKEN not set (required for --sign push)"))?;
-    let head_ref = repo.head()?;
-    let branch_name = head_ref
-        .shorthand()
-        .ok_or_else(|| anyhow::anyhow!("HEAD has no branch name"))?;
-    let refspec = format!("refs/heads/{branch_name}:refs/heads/{branch_name}");
-    let mut remote = repo.find_remote("origin")?;
-    let mut callbacks = git2::RemoteCallbacks::new();
-    callbacks.credentials(move |_url, _username, allowed| {
-        if allowed.contains(git2::CredentialType::USER_PASS_PLAINTEXT) {
-            git2::Cred::userpass_plaintext("x-access-token", &token)
-        } else {
-            Err(git2::Error::from_str(
-                "remote requires SSH auth; ensure remote URL uses HTTPS",
-            ))
-        }
-    });
-    let mut push_opts = git2::PushOptions::new();
-    push_opts.remote_callbacks(callbacks);
-    remote
-        .push(&[refspec.as_str()], Some(&mut push_opts))
-        .map_err(|e| anyhow::anyhow!("Push failed: {e}"))?;
-    Ok(())
 }
 
 fn save_git_push(repo: &git2::Repository) -> Result<()> {
@@ -1973,28 +1941,6 @@ mod tests {
         } else {
             panic!("expected Save variant");
         }
-    }
-
-    #[test]
-    fn test_save_push_with_github_token_missing_token() {
-        let dir = TempDir::new().unwrap();
-        // Initialise a repo with an origin remote (no commits needed — token
-        // check happens before any git operation).
-        let repo = git2::Repository::init(dir.path()).unwrap();
-        repo.remote("origin", "https://github.com/example/repo.git")
-            .unwrap();
-        let saved = std::env::var("GITHUB_TOKEN").ok();
-        std::env::remove_var("GITHUB_TOKEN");
-        let result = save_push_with_github_token(&repo);
-        if let Some(t) = saved {
-            std::env::set_var("GITHUB_TOKEN", t);
-        }
-        assert!(result.is_err(), "should fail when GITHUB_TOKEN is absent");
-        let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("GITHUB_TOKEN"),
-            "error must mention GITHUB_TOKEN: {msg}"
-        );
     }
 
     // --- publish subcommand tests ---

--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -883,10 +883,12 @@ fn run_save_signed(
         .map_err(|e| anyhow::anyhow!("Failed to sign and commit: {}", e))?;
     println!("Created signed commit: {message}");
     if push {
-        let bot_name = std::env::var("BOT_USER_NAME").unwrap_or_else(|_| "bot".to_string());
-        client
-            .push_commit("", None, false, &bot_name)
-            .map_err(|e| anyhow::anyhow!("Failed to push: {}", e))?;
+        // Use GITHUB_TOKEN via HTTPS rather than pcu's push_commit, which
+        // falls back to CredentialHandler / SSH agent when USER_PASS_PLAINTEXT
+        // is not offered — picking up the read-only CircleCI deploy key.
+        let repo = git2::Repository::discover(".")
+            .map_err(|e| anyhow::anyhow!("Not inside a git repository: {}", e))?;
+        save_push_with_github_token(&repo)?;
         println!("Pushed to remote.");
     }
     Ok(())
@@ -965,6 +967,36 @@ fn save_create_commit(
     let new_tree = repo.find_tree(new_tree_oid)?;
     let parents: Vec<&git2::Commit> = head_commit.into_iter().collect();
     Ok(repo.commit(Some("HEAD"), &sig, &sig, message, &new_tree, &parents)?)
+}
+
+/// Push the current branch to `origin` using `GITHUB_TOKEN` for HTTPS auth.
+/// Refuses SSH credential types so a read-only deploy key can never be used
+/// as a fallback.
+fn save_push_with_github_token(repo: &git2::Repository) -> Result<()> {
+    let token = std::env::var("GITHUB_TOKEN")
+        .map_err(|_| anyhow::anyhow!("GITHUB_TOKEN not set (required for --sign push)"))?;
+    let head_ref = repo.head()?;
+    let branch_name = head_ref
+        .shorthand()
+        .ok_or_else(|| anyhow::anyhow!("HEAD has no branch name"))?;
+    let refspec = format!("refs/heads/{branch_name}:refs/heads/{branch_name}");
+    let mut remote = repo.find_remote("origin")?;
+    let mut callbacks = git2::RemoteCallbacks::new();
+    callbacks.credentials(move |_url, _username, allowed| {
+        if allowed.contains(git2::CredentialType::USER_PASS_PLAINTEXT) {
+            git2::Cred::userpass_plaintext("x-access-token", &token)
+        } else {
+            Err(git2::Error::from_str(
+                "remote requires SSH auth; ensure remote URL uses HTTPS",
+            ))
+        }
+    });
+    let mut push_opts = git2::PushOptions::new();
+    push_opts.remote_callbacks(callbacks);
+    remote
+        .push(&[refspec.as_str()], Some(&mut push_opts))
+        .map_err(|e| anyhow::anyhow!("Push failed: {e}"))?;
+    Ok(())
 }
 
 fn save_git_push(repo: &git2::Repository) -> Result<()> {
@@ -1941,6 +1973,28 @@ mod tests {
         } else {
             panic!("expected Save variant");
         }
+    }
+
+    #[test]
+    fn test_save_push_with_github_token_missing_token() {
+        let dir = TempDir::new().unwrap();
+        // Initialise a repo with an origin remote (no commits needed — token
+        // check happens before any git operation).
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        repo.remote("origin", "https://github.com/example/repo.git")
+            .unwrap();
+        let saved = std::env::var("GITHUB_TOKEN").ok();
+        std::env::remove_var("GITHUB_TOKEN");
+        let result = save_push_with_github_token(&repo);
+        if let Some(t) = saved {
+            std::env::set_var("GITHUB_TOKEN", t);
+        }
+        assert!(result.is_err(), "should fail when GITHUB_TOKEN is absent");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("GITHUB_TOKEN"),
+            "error must mention GITHUB_TOKEN: {msg}"
+        );
     }
 
     // --- publish subcommand tests ---


### PR DESCRIPTION
## Summary

- **Cognitive complexity**: Splits `run_save` into `run_save_signed` / `run_save_unsigned` helpers to bring complexity from 16 to within the 15 limit (addresses SonarQube issue)
- **SSH push failure**: CircleCI's `checkout` step clones via SSH, leaving `git@github.com` as the remote. pcu's `push_commit` credential callback only reaches `USER_PASS_PLAINTEXT` (GitHub App token) for HTTPS remotes; SSH remotes fall through to `CredentialHandler` which picks up the read-only CircleCI deploy key. Fix: `git remote set-url origin https://...` in `build-mcp-server`'s setup step — matching the pattern used in the circleci-toolkit `build_mcp_server` job

## Test plan

- [ ] All 218 unit tests pass (`cargo test`)
- [ ] `cargo clippy --all --tests --all-features -- -D warnings` clean
- [ ] `cargo fmt --all --check` clean
- [ ] Next release pipeline: `build-mcp-server` "Commit back generated artifacts" step should succeed, landing `prior-versions/` and `migrations/` on main for the first time

🤖 Generated with [Claude Code](https://claude.com/claude-code)