### PR TITLE
chore(logging): bridge log→tracing + CI push diagnostics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
       - run:
           name: Commit back generated artifacts
           command: |
-            echo "Remote URL: $(git remote get-url origin)"
+            git remote -v
             RUST_LOG=info gen-orb-mcp save \
               --paths prior-versions \
               --paths migrations \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,8 @@ jobs:
       - run:
           name: Commit back generated artifacts
           command: |
-            gen-orb-mcp save \
+            echo "Remote URL: $(git remote get-url origin)"
+            RUST_LOG=info gen-orb-mcp save \
               --paths prior-versions \
               --paths migrations \
               --sign

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,6 +1871,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "trycmd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ handlebars = "6.4.0"
 # Logging
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+tracing-log = "0.2.0"
 
 # Date/time — for --since cutoff calculation
 chrono = { version = "0.4.44", features = ["std"], default-features = false }

--- a/crates/gen-orb-mcp/Cargo.toml
+++ b/crates/gen-orb-mcp/Cargo.toml
@@ -36,6 +36,7 @@ handlebars.workspace = true
 # Logging
 tracing.workspace = true
 tracing-subscriber.workspace = true
+tracing-log.workspace = true
 
 # Date/time and semver (for prime command)
 chrono.workspace = true

--- a/crates/gen-orb-mcp/src/main.rs
+++ b/crates/gen-orb-mcp/src/main.rs
@@ -4,6 +4,10 @@ use gen_orb_mcp::Cli;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 fn main() -> Result<()> {
+    // Bridge `log` crate records (used by pcu and git2_credentials) into the
+    // tracing subscriber so they appear when RUST_LOG is set.
+    tracing_log::LogTracer::init()?;
+
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()


### PR DESCRIPTION
## Summary

- Adds `tracing-log` dependency and initialises `LogTracer` in `main.rs`, routing all `log::info!` / `log::debug!` records from pcu and git2_credentials through the tracing subscriber
- Sets `RUST_LOG=info` in the "Commit back generated artifacts" CI step so pcu's push authentication logs appear
- Echoes the git remote URL at the start of the step to confirm whether HTTPS or SSH is active when `gen-orb-mcp save --sign` runs

## What the next run will show

With `RUST_LOG=info`, pcu logs:
- `Push target: <url>` — actual remote URL used by pcu
- `Push auth: url=..., credential_types=...` — whether `USER_PASS_PLAINTEXT` (App token) or `SSH_KEY` (read-only deploy key) is offered

## Test plan

- [ ] `cargo test` — 218 tests pass
- [ ] `cargo clippy` clean
- [ ] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)