### PR TITLE
fix(logging): add log→tracing bridge without SetLoggerError panic

### DIFF
--- a/crates/gen-orb-mcp/src/main.rs
+++ b/crates/gen-orb-mcp/src/main.rs
@@ -4,10 +4,9 @@ use gen_orb_mcp::Cli;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 fn main() -> Result<()> {
-    // Bridge `log` crate records (used by pcu and git2_credentials) into the
-    // tracing subscriber so they appear when RUST_LOG is set.
-    tracing_log::LogTracer::init()?;
-
+    // tracing_subscriber::init() calls LogTracer::init() automatically when
+    // the tracing-log feature is active (unified via dependency tree).
+    // Calling it manually beforehand causes a SetLoggerError panic.
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()


### PR DESCRIPTION
## Summary

- Adds `tracing-log` dependency to bridge `log::info!` records from pcu and git2_credentials through the tracing subscriber (needed to see pcu's push auth diagnostic output with `RUST_LOG=info`)
- Removes the explicit `LogTracer::init()?` call — `tracing_subscriber::init()` already calls it internally when the feature is active via the dependency tree; calling it twice causes `SetLoggerError` and panics every subcommand
- CI: replaces `git remote get-url origin` (fetch URL only) with `git remote -v` (shows both fetch and push URLs) and enables `RUST_LOG=info` in the save step

## Expected output on next failure

```
origin  git@github.com:... (fetch)
origin  git@github.com:... (push)    ← or https:// if the set-url worked
...
INFO pcu: Push target: <url>
INFO pcu: Push auth: url=..., credential_types=...
```

This will confirm whether the remote URL change is taking effect and which credential type git2 is actually using.

## Test plan

- [ ] 218 tests pass
- [ ] `cargo clippy` clean
- [ ] `cargo fmt --check` clean
- [ ] Binary no longer panics on any subcommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)