### PR TITLE
fix(ci): set HTTPS push URL in build-mcp-server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ workflows:
                 - /pull\/[0-9]+/
                 - main
 
-      - verify-git-https-setup:
+      - verify-git-https-setup
 
       - gen-circleci-orb/build_rust_binary:
           name: build-binary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,21 @@ orbs:
   orb-tools: circleci/orb-tools@12.4.0
   gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.16
 
+commands:
+  set-https-remote:
+    description: >
+      Rewrite both the fetch and push URLs for origin to HTTPS.
+      CircleCI checkout sets both to SSH; git2 (used by pcu push_commit)
+      only offers USER_PASS_PLAINTEXT for HTTPS remotes — SSH remotes
+      fall back to the read-only deploy key.
+    steps:
+      - run:
+          name: Set HTTPS remote URLs (fetch and push)
+          command: |
+            HTTPS_ORIGIN="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
+            git remote set-url origin "${HTTPS_ORIGIN}"
+            git remote set-url --push origin "${HTTPS_ORIGIN}"
+
 jobs:
   orb-release-binary:
     docker:
@@ -64,13 +79,7 @@ jobs:
             echo "export CIRCLE_BRANCH=main" >> "$BASH_ENV"
             git fetch origin main
             git checkout -B main origin/main
-            # CircleCI checkout sets separate fetch and push URLs, both SSH.
-            # The push URL must be HTTPS so pcu's push_commit receives
-            # USER_PASS_PLAINTEXT (GitHub App token) rather than SSH_KEY
-            # credential types (which fall back to the read-only deploy key).
-            HTTPS_ORIGIN="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
-            git remote set-url origin "${HTTPS_ORIGIN}"
-            git remote set-url --push origin "${HTTPS_ORIGIN}"
+      - set-https-remote
       - run:
           name: Prime prior versions and migrations
           command: |
@@ -112,13 +121,14 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Verify HTTPS remote setup (fetch and push)
+          name: Show remote URLs before transformation
           command: |
             echo "=== Before ==="
             git remote -v
-            HTTPS_ORIGIN="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
-            git remote set-url origin "${HTTPS_ORIGIN}"
-            git remote set-url --push origin "${HTTPS_ORIGIN}"
+      - set-https-remote
+      - run:
+          name: Assert both remote URLs are HTTPS
+          command: |
             echo "=== After ==="
             git remote -v
             fetch_url=$(git remote get-url origin)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,35 @@ jobs:
               --paths migrations \
               --sign
 
+  verify-git-https-setup:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run:
+          name: Verify HTTPS remote setup (fetch and push)
+          command: |
+            echo "=== Before ==="
+            git remote -v
+            HTTPS_ORIGIN="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
+            git remote set-url origin "${HTTPS_ORIGIN}"
+            git remote set-url --push origin "${HTTPS_ORIGIN}"
+            echo "=== After ==="
+            git remote -v
+            fetch_url=$(git remote get-url origin)
+            push_url=$(git remote get-url --push origin)
+            echo "Fetch URL: ${fetch_url}"
+            echo "Push URL:  ${push_url}"
+            if ! echo "${fetch_url}" | grep -q "^https://"; then
+              echo "FAIL: fetch URL is not HTTPS"
+              exit 1
+            fi
+            if ! echo "${push_url}" | grep -q "^https://"; then
+              echo "FAIL: push URL is not HTTPS"
+              exit 1
+            fi
+            echo "PASS: both fetch and push URLs are HTTPS"
+
   orb-release-ensure-registered:
     executor: orb-tools/default
     steps:
@@ -206,6 +235,8 @@ workflows:
               ignore:
                 - /pull\/[0-9]+/
                 - main
+
+      - verify-git-https-setup:
 
       - gen-circleci-orb/build_rust_binary:
           name: build-binary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,17 +21,15 @@ commands:
       - run:
           name: Set HTTPS remote URLs (fetch and push)
           command: |
-            echo "--- insteadOf rules in effect ---"
-            git config --list --show-origin | grep -i instead || echo "(none)"
-            echo "--- local remote config ---"
-            git config --local --list | grep remote || echo "(none)"
+            # CircleCI's checkout step injects an insteadOf rule into ~/.gitconfig:
+            #   url."ssh://git@github.com".insteadOf = https://github.com
+            # This causes git (and libgit2 used by pcu) to transparently rewrite
+            # every HTTPS GitHub URL back to SSH, so git remote set-url has no
+            # observable effect on the effective URL. Remove the rule first.
+            git config --global --unset-all "url.ssh://git@github.com.insteadOf" 2>/dev/null || true
             HTTPS_ORIGIN="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
-            echo "--- target URL: ${HTTPS_ORIGIN} ---"
             git remote set-url origin "${HTTPS_ORIGIN}"
             git remote set-url --push origin "${HTTPS_ORIGIN}"
-            echo "--- after set-url ---"
-            git remote -v
-            git config --local --list | grep remote
 
 jobs:
   orb-release-binary:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,17 @@ commands:
       - run:
           name: Set HTTPS remote URLs (fetch and push)
           command: |
+            echo "--- insteadOf rules in effect ---"
+            git config --list --show-origin | grep -i instead || echo "(none)"
+            echo "--- local remote config ---"
+            git config --local --list | grep remote || echo "(none)"
             HTTPS_ORIGIN="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
+            echo "--- target URL: ${HTTPS_ORIGIN} ---"
             git remote set-url origin "${HTTPS_ORIGIN}"
             git remote set-url --push origin "${HTTPS_ORIGIN}"
+            echo "--- after set-url ---"
+            git remote -v
+            git config --local --list | grep remote
 
 jobs:
   orb-release-binary:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,13 @@ jobs:
             echo "export CIRCLE_BRANCH=main" >> "$BASH_ENV"
             git fetch origin main
             git checkout -B main origin/main
-            # CircleCI checkout clones via SSH (deploy key in agent is read-only).
-            # Switch to HTTPS so pcu's push_commit uses USER_PASS_PLAINTEXT and
-            # the GitHub App token rather than falling back to the SSH deploy key.
-            git remote set-url origin \
-              "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
+            # CircleCI checkout sets separate fetch and push URLs, both SSH.
+            # The push URL must be HTTPS so pcu's push_commit receives
+            # USER_PASS_PLAINTEXT (GitHub App token) rather than SSH_KEY
+            # credential types (which fall back to the read-only deploy key).
+            HTTPS_ORIGIN="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
+            git remote set-url origin "${HTTPS_ORIGIN}"
+            git remote set-url --push origin "${HTTPS_ORIGIN}"
       - run:
           name: Prime prior versions and migrations
           command: |


### PR DESCRIPTION
## Summary

- CircleCI `checkout` configures **separate** fetch and push URLs in `.git/config`, both pointing to SSH
- `git remote set-url origin https://...` only rewrites the fetch URL; the `pushurl` config key remains SSH
- git2's `push_commit` uses `pushurl` for the actual push transport, picking up the read-only deploy key instead of the GitHub App token
- Add `git remote set-url --push origin "${HTTPS_ORIGIN}"` to also rewrite the push URL so pcu receives `USER_PASS_PLAINTEXT` credentials

## Root cause evidence

Pipeline diagnostic logs confirmed:
```
origin  ssh://git@github.com/jerus-org/gen-orb-mcp.git (fetch)
origin  ssh://git@github.com/jerus-org/gen-orb-mcp.git (push)   ← was not changed
```
pcu logs: `Push target: ssh://git@...` and `credential_types=CredentialType(SSH_KEY | SSH_MEMORY | SSH_CUSTOM)`

## Test plan

- [ ] Next release triggers `build-mcp-server` job
- [ ] `git remote -v` in setup step shows HTTPS for both fetch and push
- [ ] pcu logs show `credential_types` includes `USER_PASS_PLAINTEXT`
- [ ] "Commit back generated artifacts" step succeeds and commits `prior-versions/` + `migrations/` to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)