### PR TITLE
feat(orb): add set_https_remote command and use in save job

### DIFF
--- a/orb/src/commands/set_https_remote.yml
+++ b/orb/src/commands/set_https_remote.yml
@@ -1,0 +1,14 @@
+description: >
+  Remove the SSH insteadOf rewrite rule that CircleCI checkout injects and
+  set both the fetch and push URLs for origin to HTTPS.
+
+  CircleCI's checkout step writes url."ssh://git@github.com".insteadOf =
+  https://github.com into ~/.gitconfig. This causes git and libgit2 (used
+  by pcu push_commit) to transparently rewrite every HTTPS GitHub URL back
+  to SSH, making git remote set-url have no observable effect on the
+  effective URL. Without this step, pcu falls back to the read-only SSH
+  deploy key instead of authenticating with the GitHub App token.
+steps:
+  - run:
+      name: Set HTTPS remote URLs (fetch and push)
+      command: <<include(scripts/set_https_remote.sh)>>

--- a/orb/src/jobs/save.yml
+++ b/orb/src/jobs/save.yml
@@ -32,6 +32,7 @@ parameters:
     default: false
 steps:
 - checkout
+- set_https_remote
 - save:
     paths: << parameters.paths >>
     message: << parameters.message >>

--- a/orb/src/scripts/set_https_remote.sh
+++ b/orb/src/scripts/set_https_remote.sh
@@ -1,0 +1,9 @@
+# CircleCI's checkout step injects this rule into ~/.gitconfig:
+#   url."ssh://git@github.com".insteadOf = https://github.com
+# This causes git (and libgit2 used by pcu) to transparently rewrite every
+# HTTPS GitHub URL back to SSH, so git remote set-url has no observable effect
+# on the effective URL. Remove the rule before setting the remote URLs.
+git config --global --unset-all "url.ssh://git@github.com.insteadOf" 2>/dev/null || true
+HTTPS_ORIGIN="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
+git remote set-url origin "${HTTPS_ORIGIN}"
+git remote set-url --push origin "${HTTPS_ORIGIN}"


### PR DESCRIPTION
## Summary

- Adds `set_https_remote` command to the gen-orb-mcp orb (independent of gen-circleci-orb)
- Updates the `save` job to call `set_https_remote` between `checkout` and `save`, making the job self-contained for push operations

## Why

The gen-orb-mcp `save` job was incomplete: it did `checkout → save` with no HTTPS remote setup. CircleCI checkout injects \`url."ssh://git@github.com".insteadOf = https://github.com\` into \`~/.gitconfig\`, causing pcu to fall back to the read-only SSH deploy key and fail.

Placing `set_https_remote` in this orb means gen-orb-mcp can be used independently of gen-circleci-orb. gen-circleci-orb retains its own copy for the `build_mcp_server` job (which does git operations outside the save job).

## Capability distribution after this PR

| Capability | gen-orb-mcp orb | gen-circleci-orb |
|---|---|---|
| Remove SSH insteadOf + set HTTPS remote | ✅ `set_https_remote` command | ✅ independent copy |
| `save` job with correct HTTPS setup | ✅ `checkout → set_https_remote → save` | — |
| Full MCP server build pipeline | — | ✅ `build_mcp_server` job |

## Test plan

- [ ] CI passes
- [ ] `circleci orb pack orb/src` produces valid YAML with `set_https_remote` in commands and as a step in the `save` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)