### PR TITLE
chore: bump gen-circleci-orb to 0.0.25, add git_push_subcommand

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
   orb-tools: circleci/orb-tools@12.4.0
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.16
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.25
 
 commands:
   set-https-remote:
@@ -265,6 +265,7 @@ workflows:
           orb_namespace: jerus-org
           orb_dir: orb
           attach_workspace: true
+          git_push_subcommand: save
           requires:
             - build-binary
       - orb-tools/pack:


### PR DESCRIPTION
## Summary

- Bumps `gen-circleci-orb` orb from `0.0.16` → `0.0.25`
- Adds `git_push_subcommand: save` to the `regenerate-orb` job

## Why

`git_push_subcommand` was added in gen-circleci-orb v0.0.25. When set, the generator inserts a `set_https_remote` step into the generated job for the named subcommand. Without this, the regenerated `orb/src/jobs/save.yml` lacks `set_https_remote`, so the save job cannot push back to the repository using the GitHub App deploy key.

## Test plan

- [ ] Validation pipeline runs `regenerate-orb` — confirm `orb/src/jobs/save.yml` now includes a `set_https_remote` step between `checkout` and `save`

🤖 Generated with [Claude Code](https://claude.com/claude-code)