### PR TITLE
fix: rename generate --version to --crate-version

### DIFF
--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -67,8 +67,8 @@ enum Commands {
         ///
         /// Required when regenerating an existing output directory.
         /// For CI workflows, this should match the orb release version.
-        #[arg(short = 'V', long)]
-        version: Option<String>,
+        #[arg(long = "crate-version")]
+        crate_version: Option<String>,
 
         /// Overwrite existing files without confirmation
         ///
@@ -314,7 +314,7 @@ impl Cli {
                 output,
                 format,
                 name,
-                version,
+                crate_version,
                 force,
                 migrations,
                 prior_versions,
@@ -324,7 +324,7 @@ impl Cli {
                 output,
                 format,
                 name,
-                version,
+                crate_version,
                 *force,
                 GenerateExtras {
                     migrations,
@@ -397,7 +397,7 @@ fn run_generate(
     output: &std::path::PathBuf,
     format: &OutputFormat,
     name: &Option<String>,
-    version: &Option<String>,
+    crate_version: &Option<String>,
     force: bool,
     extras: GenerateExtras<'_>,
 ) -> Result<()> {
@@ -418,7 +418,8 @@ fn run_generate(
         Ok(repo) => discover_latest_version(&repo, extras.tag_prefix)?,
         Err(_) => None,
     };
-    let resolved_version = resolve_version(output, version.as_deref(), force, git_hint.as_deref())?;
+    let resolved_version =
+        resolve_version(output, crate_version.as_deref(), force, git_hint.as_deref())?;
     tracing::info!(version = %resolved_version, "Using version");
 
     let conformance_rules = if let Some(migrations_dir) = extras.migrations {
@@ -1258,7 +1259,7 @@ fn resolve_version(
         format!(
             "Output directory '{}' already exists and no version could be determined.\n\
              Provide the version explicitly:\n\n\
-             \x20   gen-orb-mcp generate --orb-path <PATH> --output {} --version <VERSION> --force\n\n\
+             \x20   gen-orb-mcp generate --orb-path <PATH> --output {} --crate-version <VERSION> --force\n\n\
              Or ensure --orb-path is inside a git repository with version tags (e.g. v6.0.0).\n\
              Use --tag-prefix if your tags use a non-standard prefix.",
             output.display(),
@@ -1268,7 +1269,7 @@ fn resolve_version(
         format!(
             "No version could be determined for the generated MCP server.\n\
              Provide the version explicitly:\n\n\
-             \x20   gen-orb-mcp generate --orb-path <PATH> --output {} --version <VERSION>\n\n\
+             \x20   gen-orb-mcp generate --orb-path <PATH> --output {} --crate-version <VERSION>\n\n\
              Or ensure --orb-path is inside a git repository with version tags (e.g. v6.0.0).\n\
              Use --tag-prefix if your tags use a non-standard prefix.",
             output.display()
@@ -1297,7 +1298,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cli_parse_generate_with_version() {
+    fn test_cli_parse_generate_with_crate_version_legacy() {
         let cli = Cli::try_parse_from([
             "gen-orb-mcp",
             "generate",
@@ -1305,7 +1306,7 @@ mod tests {
             "test.yml",
             "--output",
             "./out",
-            "--version",
+            "--crate-version",
             "1.2.3",
         ]);
         assert!(cli.is_ok());
@@ -1320,11 +1321,44 @@ mod tests {
             "test.yml",
             "--output",
             "./out",
-            "--version",
+            "--crate-version",
             "1.2.3",
             "--force",
         ]);
         assert!(cli.is_ok());
+    }
+
+    #[test]
+    fn test_cli_parse_generate_with_crate_version() {
+        let cli = Cli::try_parse_from([
+            "gen-orb-mcp",
+            "generate",
+            "--orb-path",
+            "test.yml",
+            "--output",
+            "./out",
+            "--crate-version",
+            "1.2.3",
+        ]);
+        assert!(cli.is_ok(), "--crate-version should be accepted");
+    }
+
+    #[test]
+    fn test_cli_parse_generate_version_flag_rejected() {
+        let cli = Cli::try_parse_from([
+            "gen-orb-mcp",
+            "generate",
+            "--orb-path",
+            "test.yml",
+            "--output",
+            "./out",
+            "--version",
+            "1.2.3",
+        ]);
+        assert!(
+            cli.is_err(),
+            "--version should be rejected (conflicts with clap built-in)"
+        );
     }
 
     #[test]
@@ -1389,7 +1423,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("already exists"));
-        assert!(err.contains("--version"));
+        assert!(err.contains("--crate-version"));
     }
 
     #[test]

--- a/orb/src/commands/generate.yml
+++ b/orb/src/commands/generate.yml
@@ -18,7 +18,7 @@ parameters:
     type: string
     description: Name for the generated orb server (defaults to filename)
     default: ''
-  version:
+  crate_version:
     type: string
     description: Version for the generated MCP server crate (e.g., "1.0.0")  Required when regenerating an existing output directory. For CI workflows, this should match the orb release version.
     default: ''
@@ -47,7 +47,7 @@ steps:
       OUTPUT: << parameters.output >>
       FORMAT: << parameters.format >>
       GENERATE_NAME: << parameters.generate_name >>
-      VERSION: << parameters.version >>
+      CRATE_VERSION: << parameters.crate_version >>
       FORCE: << parameters.force >>
       MIGRATIONS: << parameters.migrations >>
       PRIOR_VERSIONS: << parameters.prior_versions >>

--- a/orb/src/jobs/generate.yml
+++ b/orb/src/jobs/generate.yml
@@ -15,7 +15,7 @@ parameters:
     enum:
     - binary
     - source
-  version:
+  crate_version:
     type: string
     description: Version for the generated MCP server crate (e.g., "1.0.0")  Required when regenerating an existing output directory. For CI workflows, this should match the orb release version.
     default: ''
@@ -41,7 +41,7 @@ steps:
     orb_path: << parameters.orb_path >>
     output: << parameters.output >>
     format: << parameters.format >>
-    version: << parameters.version >>
+    crate_version: << parameters.crate_version >>
     force: << parameters.force >>
     migrations: << parameters.migrations >>
     prior_versions: << parameters.prior_versions >>

--- a/orb/src/scripts/generate.sh
+++ b/orb/src/scripts/generate.sh
@@ -1,11 +1,11 @@
 set -- gen-orb-mcp generate
 set -- "$@" --orb-path "${ORB_PATH}"
-[ -n "${OUTPUT:-}" ] && set -- "$@" --output "${OUTPUT}"
-[ -n "${FORMAT:-}" ] && set -- "$@" --format "${FORMAT}"
-[ -n "${GENERATE_NAME:-}" ] && set -- "$@" --name "${GENERATE_NAME}"
-[ -n "${CRATE_VERSION:-}" ] && set -- "$@" --crate-version "${CRATE_VERSION}"
-[ "${FORCE:-false}" = "true" ] && set -- "$@" --force
-[ -n "${MIGRATIONS:-}" ] && set -- "$@" --migrations "${MIGRATIONS}"
-[ -n "${PRIOR_VERSIONS:-}" ] && set -- "$@" --prior-versions "${PRIOR_VERSIONS}"
-[ -n "${TAG_PREFIX:-}" ] && set -- "$@" --tag-prefix "${TAG_PREFIX}"
+[[ -n "${OUTPUT:-}" ]] && set -- "$@" --output "${OUTPUT}"
+[[ -n "${FORMAT:-}" ]] && set -- "$@" --format "${FORMAT}"
+[[ -n "${GENERATE_NAME:-}" ]] && set -- "$@" --name "${GENERATE_NAME}"
+[[ -n "${CRATE_VERSION:-}" ]] && set -- "$@" --crate-version "${CRATE_VERSION}"
+[[ "${FORCE:-false}" = "true" ]] && set -- "$@" --force
+[[ -n "${MIGRATIONS:-}" ]] && set -- "$@" --migrations "${MIGRATIONS}"
+[[ -n "${PRIOR_VERSIONS:-}" ]] && set -- "$@" --prior-versions "${PRIOR_VERSIONS}"
+[[ -n "${TAG_PREFIX:-}" ]] && set -- "$@" --tag-prefix "${TAG_PREFIX}"
 "$@"

--- a/orb/src/scripts/generate.sh
+++ b/orb/src/scripts/generate.sh
@@ -3,7 +3,7 @@ set -- "$@" --orb-path "${ORB_PATH}"
 [ -n "${OUTPUT:-}" ] && set -- "$@" --output "${OUTPUT}"
 [ -n "${FORMAT:-}" ] && set -- "$@" --format "${FORMAT}"
 [ -n "${GENERATE_NAME:-}" ] && set -- "$@" --name "${GENERATE_NAME}"
-[ -n "${VERSION:-}" ] && set -- "$@" --version "${VERSION}"
+[ -n "${CRATE_VERSION:-}" ] && set -- "$@" --crate-version "${CRATE_VERSION}"
 [ "${FORCE:-false}" = "true" ] && set -- "$@" --force
 [ -n "${MIGRATIONS:-}" ] && set -- "$@" --migrations "${MIGRATIONS}"
 [ -n "${PRIOR_VERSIONS:-}" ] && set -- "$@" --prior-versions "${PRIOR_VERSIONS}"


### PR DESCRIPTION
## Summary

- Renames the `generate` subcommand's `--version`/`-V` flag to `--crate-version`
- Removes the short `-V` alias (which conflicts with clap's built-in version flag)
- Updates `orb/src/commands/generate.yml`: `version:` parameter → `crate_version:`, env var `VERSION` → `CRATE_VERSION`
- Updates `orb/src/scripts/generate.sh`: `--version "${VERSION}"` → `--crate-version "${CRATE_VERSION}"`
- Updates all tests and error messages

Closes #109

## Test plan

- [x] `test_cli_parse_generate_with_crate_version` — accepts `--crate-version`
- [x] `test_cli_parse_generate_version_flag_rejected` — rejects `--version` as unknown flag
- [x] Full test suite passes (`cargo test -p gen-orb-mcp`)
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all --tests --all-features -- -D warnings` passes
- [x] `cargo audit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)