### PR TITLE
chore: group git2 and git2_credentials in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,12 @@
   ],
   "extends": [
     "github>jerusdp/renovate-config:default.json"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["git2", "git2_credentials"],
+      "groupName": "git2 packages",
+      "description": "git2 and git2_credentials must update together: git2_credentials pins a specific git2 minor version"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Groups `git2` and `git2_credentials` in a Renovate `packageRules` entry so they are always updated in a single PR
- `git2_credentials` pins a specific `git2` minor version; bumping one without the other creates two incompatible `git2` versions in the dependency graph, causing build failures (see PR #163 which was closed for this reason)

## Test plan

- [x] No code changes — Renovate config only
- [x] Next time Renovate detects a `git2` update it will wait until `git2_credentials` also has a compatible update and open a single grouped PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)