### PR TITLE
feat: default --orb-path to src/@orb.yml in generate and validate

### DIFF
--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -48,7 +48,7 @@ enum Commands {
     /// Generate an MCP server from an orb definition
     Generate {
         /// Path to the orb YAML file (e.g., src/@orb.yml)
-        #[arg(short = 'p', long)]
+        #[arg(short = 'p', long, default_value = "src/@orb.yml")]
         orb_path: std::path::PathBuf,
 
         /// Output directory for generated server
@@ -104,7 +104,7 @@ enum Commands {
     /// Validate an orb definition without generating
     Validate {
         /// Path to the orb YAML file
-        #[arg(short = 'p', long)]
+        #[arg(short = 'p', long, default_value = "src/@orb.yml")]
         orb_path: std::path::PathBuf,
     },
     /// Compute conformance rules by diffing two orb versions
@@ -1295,6 +1295,36 @@ mod tests {
             "./out",
         ]);
         assert!(cli.is_ok());
+    }
+
+    #[test]
+    fn test_cli_parse_generate_default_orb_path() {
+        let cli = Cli::try_parse_from(["gen-orb-mcp", "generate"]);
+        assert!(
+            cli.is_ok(),
+            "generate should work without --orb-path (default: src/@orb.yml)"
+        );
+        if let Ok(Cli {
+            command: Commands::Generate { orb_path, .. },
+        }) = cli
+        {
+            assert_eq!(orb_path, std::path::PathBuf::from("src/@orb.yml"));
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_validate_default_orb_path() {
+        let cli = Cli::try_parse_from(["gen-orb-mcp", "validate"]);
+        assert!(
+            cli.is_ok(),
+            "validate should work without --orb-path (default: src/@orb.yml)"
+        );
+        if let Ok(Cli {
+            command: Commands::Validate { orb_path },
+        }) = cli
+        {
+            assert_eq!(orb_path, std::path::PathBuf::from("src/@orb.yml"));
+        }
     }
 
     #[test]

--- a/orb/src/commands/generate.yml
+++ b/orb/src/commands/generate.yml
@@ -3,6 +3,7 @@ parameters:
   orb_path:
     type: string
     description: Path to the orb YAML file (e.g., src/@orb.yml)
+    default: src/@orb.yml
   output:
     type: string
     description: Output directory for generated server

--- a/orb/src/commands/validate.yml
+++ b/orb/src/commands/validate.yml
@@ -3,6 +3,7 @@ parameters:
   orb_path:
     type: string
     description: Path to the orb YAML file
+    default: src/@orb.yml
 steps:
 - run:
     name: validate

--- a/orb/src/jobs/generate.yml
+++ b/orb/src/jobs/generate.yml
@@ -4,6 +4,7 @@ parameters:
   orb_path:
     type: string
     description: Path to the orb YAML file (e.g., src/@orb.yml)
+    default: src/@orb.yml
   output:
     type: string
     description: Output directory for generated server

--- a/orb/src/jobs/validate.yml
+++ b/orb/src/jobs/validate.yml
@@ -4,6 +4,7 @@ parameters:
   orb_path:
     type: string
     description: Path to the orb YAML file
+    default: src/@orb.yml
 steps:
 - checkout
 - validate:


### PR DESCRIPTION
## Summary

- Adds `default_value = "src/@orb.yml"` to `--orb-path` on `generate` and `validate`, making them consistent with `prime` which already had this default
- Updates the corresponding orb command and job YAMLs (`commands/generate.yml`, `commands/validate.yml`, `jobs/generate.yml`, `jobs/validate.yml`) so the `orb_path` parameter is optional in generated orb callers too

`src/@orb.yml` is the documented CircleCI orb convention; requiring users to spell it out explicitly was an unnecessary friction point.

Closes #110

## Test plan

- [x] `test_cli_parse_generate_default_orb_path` — `generate` parses without `--orb-path` and defaults to `src/@orb.yml`
- [x] `test_cli_parse_validate_default_orb_path` — `validate` parses without `--orb-path` and defaults to `src/@orb.yml`
- [x] Full test suite passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all --tests --all-features -- -D warnings` passes
- [x] `cargo audit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)