### PR TITLE
chore(ci): bump gen-circleci-orb orb to 0.0.26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
   orb-tools: circleci/orb-tools@12.4.0
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.25
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.26
 
 commands:
   set-https-remote:


### PR DESCRIPTION
## Summary

- Bumps `gen-circleci-orb` orb in `config.yml` from `@0.0.25` → `@0.0.26`

## Why

The `build-mcp-server` step in the `orb-release` workflow runs inside `jerusdp/gen-orb-mcp:latest`. With gen-orb-mcp 0.1.30 the `generate` flag was renamed `--version` → `--crate-version`. The orb script in `@0.0.25` still passed `--version`, causing the step to fail.

`@0.0.26` contains the fix (PR #61 in gen-circleci-orb). Updating to it here unblocks the `orb-release` pipeline.

## Test plan

- [ ] `orb-release` workflow `build-mcp-server` step passes after next crate release

🤖 Generated with [Claude Code](https://claude.com/claude-code)