### PR TITLE
fix(ci): use --crate-version in inline build-mcp-server job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
               --name gen-orb-mcp \
               --orb-path orb/src/@orb.yml \
               --output /tmp/mcp-server \
-              --version "${VERSION}" \
+              --crate-version "${VERSION}" \
               --force \
               --prior-versions prior-versions \
               --migrations migrations


### PR DESCRIPTION
## Summary

- Fixes `--version` → `--crate-version` in the inline `build-mcp-server` job in `.circleci/config.yml` (line 104)

## Root cause

The `orb-release` workflow uses an inline `build-mcp-server` job (not the gen-circleci-orb orb job). This inline job directly called `gen-orb-mcp generate --version` which was the old flag name before PR #165 renamed it to `--crate-version`. The orb pin update (PR #168) didn't fix this because the inline job bypasses the orb entirely.

## Test plan

- [ ] `orb-release` `build-mcp-server` step passes on next crate release

🤖 Generated with [Claude Code](https://claude.com/claude-code)