### PR TITLE
chore(ci): bump gen-circleci-orb orb to 0.0.29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
   orb-tools: circleci/orb-tools@12.4.0
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.28
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.29
 
 workflows:
   validation:


### PR DESCRIPTION
Picks up the fixed `ensure_orb_registered` job from gen-circleci-orb 0.0.29.

The 0.0.28 version used `circleci setup` for CLI auth, which was removed in newer CLI releases — causing `orb-release-ensure-registered-jerus-org` to fail immediately. 0.0.29 replaces the setup call with `CIRCLECI_CLI_TOKEN` env var auth and adds `ensure-orb-registered` as a proper CLI subcommand so the script will be auto-generated in future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)