### PR TITLE
fix: add libssl-dev and pkg-config to Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
   orb-tools: circleci/orb-tools@12.4.0
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.30
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.31
 
 workflows:
   validation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
   orb-tools: circleci/orb-tools@12.4.0
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.31
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.32
 
 workflows:
   validation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
   orb-tools: circleci/orb-tools@12.4.0
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.29
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.30
 
 workflows:
   validation:

--- a/orb/Dockerfile
+++ b/orb/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:slim@sha256:e14e87345b4d5964ddcc3491d27ee046a0f23820f340c3c1e24da6880141f7c0
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates git gnupg openssh-client \
+    && apt-get install -y --no-install-recommends ca-certificates git gnupg libssl-dev openssh-client pkg-config \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -ms /bin/bash circleci
 COPY gen-orb-mcp /usr/local/bin/gen-orb-mcp


### PR DESCRIPTION
## Summary

- Adds `libssl-dev` and `pkg-config` to the `orb/Dockerfile` package list (sorted: `ca-certificates git gnupg libssl-dev openssh-client pkg-config`)
- Bumps `gen-circleci-orb` orb pin from `0.0.29` to `0.0.30`

## Root cause

`gen-orb-mcp generate --format binary` compiles a Rust MCP server binary at runtime inside the `jerusdp/gen-orb-mcp` container. The `openssl-sys` crate requires `libssl-dev` (headers) and `pkg-config` (to locate OpenSSL) at compile time. Both were absent from the container image, causing the `build-mcp-server` release job to fail with an openssl-sys error.

## Test plan

- [x] `orb/Dockerfile` updated — packages are sorted alphanumerically (SonarQube S7018)
- [x] Next release will build a new `jerusdp/gen-orb-mcp` image with `libssl-dev` and `pkg-config` installed, fixing the `build-mcp-server` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)