### PR TITLE
feat: initialise orb wiring with gen-circleci-orb v0.0.38

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
 
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.38
+  orb-tools: circleci/orb-tools@12.3.3
 workflows:
   validation:
     jobs:
@@ -78,3 +80,111 @@ workflows:
                 - /pull\/[0-9]+/
                 - main
 
+      - gen-circleci-orb/build_rust_binary:
+          name: build-binary
+          package: gen-orb-mcp
+          requires: [toolkit/common_tests]
+      - gen-circleci-orb/generate:
+          name: regenerate-orb
+          binary: gen-orb-mcp
+          orb_namespace: jerus-org
+          orb_dir: orb
+          attach_workspace: true
+          requires: [build-binary]
+      - orb-tools/pack:
+          name: pack-orb
+          source_dir: orb/src
+          requires: [regenerate-orb]
+      - orb-tools/review:
+          name: review-orb
+          source_dir: orb/src
+          requires: [pack-orb]
+
+  orb-release:
+    jobs:
+      - gen-circleci-orb/build_rust_binary:
+          name: orb-release-binary
+          package: gen-orb-mcp
+          filters:
+            tags:
+              only: /^gen-orb-mcp-v.*/
+            branches:
+              ignore: /.*/
+
+      - orb-tools/pack:
+          name: orb-release-pack
+          checkout: false
+          source_dir: orb/src
+          pre-steps:
+            - checkout
+            - run:
+                name: Inject release version into executor default tag
+                command: |
+                  VERSION=${CIRCLE_TAG#gen-orb-mcp-v}
+                  echo "Injecting version: ${VERSION}"
+                  sed -i "s/default: latest/default: ${VERSION}/" orb/src/executors/default.yml
+                  echo "Updated executor:"
+                  cat orb/src/executors/default.yml
+          filters:
+            tags:
+              only: /^gen-orb-mcp-v.*/
+            branches:
+              ignore: /.*/
+
+      - gen-circleci-orb/build_container:
+          name: orb-release-container
+          binary: gen-orb-mcp
+          docker_namespace: jerusdp
+          orb_dir: orb
+          crate_tag_prefix: gen-orb-mcp-v
+          requires: [orb-release-binary]
+          context: [docker]
+          filters:
+            tags:
+              only: /^gen-orb-mcp-v.*/
+            branches:
+              ignore: /.*/
+
+      - gen-circleci-orb/ensure_orb_registered:
+          name: orb-release-ensure-registered-jerus-org
+          orb_name: jerus-org/gen-orb-mcp
+          context: [orb-publishing]
+          filters:
+            tags:
+              only: /^gen-orb-mcp-v.*/
+            branches:
+              ignore: /.*/
+
+      - orb-tools/publish:
+          name: publish-orb-jerus-org
+          pre-steps:
+            - run:
+                name: Normalize CIRCLE_TAG for orb version
+                command: |
+                  VERSION=${CIRCLE_TAG#gen-orb-mcp-v}
+                  echo "export CIRCLE_TAG=v${VERSION}" >> "$BASH_ENV"
+          orb_name: jerus-org/gen-orb-mcp
+          pub_type: production
+          vcs_type: github
+          enable_pr_comment: false
+          requires: [orb-release-container, orb-release-pack, orb-release-ensure-registered-jerus-org]
+          context: [orb-publishing]
+          filters:
+            tags:
+              only: /^gen-orb-mcp-v.*/
+            branches:
+              ignore: /.*/
+
+      - gen-circleci-orb/build_mcp_server:
+          name: build-mcp-server
+          binary_name: gen-orb-mcp
+          tag_prefix: gen-orb-mcp-v
+          orb_path: orb/src/@orb.yml
+          earliest_version: "0.1.11"
+          requires: [publish-orb-jerus-org]
+          context: [release, bot-check, pcu-app]
+          filters:
+            tags:
+              only: /^gen-orb-mcp-v.*/
+            branches:
+              ignore: /.*/

--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -1,0 +1,25 @@
+[orb]
+binary = "gen-orb-mcp"
+namespaces = ["jerus-org"]
+orb_dir = "orb"
+git_push_subcommands = ["save"]
+
+[ci]
+build_workflow = "validation"
+release_workflow = "release"
+requires_job = "toolkit/common_tests"
+release_after_job = "release-gen-orb-mcp"
+crate_tag_prefix = "gen-orb-mcp-v"
+docker_namespace = "jerusdp"
+docker_context = "docker"
+orb_context = "orb-publishing"
+mcp = true
+mcp_context = [
+    "release",
+    "bot-check",
+    "pcu-app",
+]
+mcp_earliest_version = "0.1.11"
+
+[subcommand.help]
+generate_job = false

--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -4,22 +4,5 @@ namespaces = ["jerus-org"]
 orb_dir = "orb"
 git_push_subcommands = ["save"]
 
-[ci]
-build_workflow = "validation"
-release_workflow = "release"
-requires_job = "toolkit/common_tests"
-release_after_job = "release-gen-orb-mcp"
-crate_tag_prefix = "gen-orb-mcp-v"
-docker_namespace = "jerusdp"
-docker_context = "docker"
-orb_context = "orb-publishing"
-mcp = true
-mcp_context = [
-    "release",
-    "bot-check",
-    "pcu-app",
-]
-mcp_earliest_version = "0.1.11"
-
 [subcommand.help]
 generate_job = false

--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -4,5 +4,22 @@ namespaces = ["jerus-org"]
 orb_dir = "orb"
 git_push_subcommands = ["save"]
 
+[ci]
+build_workflow = "validation"
+release_workflow = "release"
+requires_job = "toolkit/common_tests"
+release_after_job = "release-gen-orb-mcp"
+crate_tag_prefix = "gen-orb-mcp-v"
+docker_namespace = "jerusdp"
+docker_context = "docker"
+orb_context = "orb-publishing"
+mcp = true
+mcp_context = [
+    "release",
+    "bot-check",
+    "pcu-app",
+]
+mcp_earliest_version = "0.1.11"
+
 [subcommand.help]
 generate_job = false

--- a/orb/Dockerfile
+++ b/orb/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:1-slim-bookworm AS builder
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl-dev pkg-config \
+    && rm -rf /var/lib/apt/lists/* \
+    && cargo install gen-orb-mcp
+
+FROM debian:12-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates git \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -ms /bin/bash circleci
+COPY --from=builder /usr/local/cargo/bin/gen-orb-mcp /usr/local/bin/gen-orb-mcp
+USER circleci
+WORKDIR /home/circleci/project

--- a/orb/src/@orb.yml
+++ b/orb/src/@orb.yml
@@ -1,0 +1,6 @@
+version: 2.1
+description: >
+  Generate MCP servers from CircleCI orb definitions, exposing commands, jobs, and executors as AI-accessible resources. Supports migration tooling, prior-version snapshots, and diff-based conformance rules to help consumers keep their CI config in sync with orb updates.
+display:
+  home_url: "https://github.com/jerus-org/gen-orb-mcp"
+  source_url: "https://github.com/jerus-org/gen-orb-mcp"

--- a/orb/src/commands/build.yml
+++ b/orb/src/commands/build.yml
@@ -1,0 +1,16 @@
+description: Compile generated MCP server source to a native binary
+parameters:
+  input:
+    type: string
+    description: Directory containing generated MCP server source
+  build_name:
+    type: string
+    description: 'Override the binary name (default: derived from Cargo.toml) --target <TARGET>  Rust target triple (default: host) --dry-run          Print the cargo command without running it'
+    default: ''
+steps:
+- run:
+    name: build
+    command: <<include(scripts/build.sh)>>
+    environment:
+      INPUT: << parameters.input >>
+      BUILD_NAME: << parameters.build_name >>

--- a/orb/src/commands/diff.yml
+++ b/orb/src/commands/diff.yml
@@ -1,0 +1,24 @@
+description: Compute conformance rules by diffing two orb versions  Compares the current orb against a previous version (read from a file) and emits a JSON array of ConformanceRule values. These rules can be passed to `generate --migrations` to embed migration tooling in the generated MCP server.
+parameters:
+  current:
+    type: string
+    description: Path to the current orb YAML (the new version)
+  previous:
+    type: string
+    description: Path to the previous orb YAML (the old version to diff against)
+  since_version:
+    type: string
+    description: The version string to embed in emitted rules (e.g. "5.0.0")
+  output:
+    type: string
+    description: 'Optional output file for the JSON rules (default: stdout)'
+    default: ''
+steps:
+- run:
+    name: diff
+    command: <<include(scripts/diff.sh)>>
+    environment:
+      CURRENT: << parameters.current >>
+      PREVIOUS: << parameters.previous >>
+      SINCE_VERSION: << parameters.since_version >>
+      OUTPUT: << parameters.output >>

--- a/orb/src/commands/generate.yml
+++ b/orb/src/commands/generate.yml
@@ -1,0 +1,55 @@
+description: Generate an MCP server from an orb definition
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML file (e.g., src/@orb.yml)
+    default: src/@orb.yml
+  output:
+    type: string
+    description: Output directory for generated server
+    default: ./dist
+  format:
+    type: enum
+    description: Output format
+    default: source
+    enum:
+    - binary
+    - source
+  generate_name:
+    type: string
+    description: Name for the generated orb server (defaults to filename)
+    default: ''
+  crate_version:
+    type: string
+    description: Version for the generated MCP server crate (e.g., "1.0.0")  Required when regenerating an existing output directory. For CI workflows, this should match the orb release version.
+    default: ''
+  force:
+    type: boolean
+    description: Overwrite existing files without confirmation  Required for non-interactive CI environments when output exists.
+    default: false
+  migrations:
+    type: string
+    description: Directory containing conformance rule JSON files to embed in the server  All *.json files in this directory are merged and embedded as migration tooling in the generated server. When provided, the server gains plan_migration and apply_migration MCP Tools in addition to Resources.
+    default: ''
+  prior_versions:
+    type: string
+    description: Directory of prior orb version YAML snapshots to embed in the server  Each file should be named `<version>.yml` (e.g., `4.7.1.yml`). The generated server will expose version-specific resources for each prior version alongside the current version.
+    default: ''
+  tag_prefix:
+    type: string
+    description: Tag prefix used to discover the orb version from git tags  The git repository is derived automatically from --orb-path. Defaults to "v" (matches tags like v6.0.0).
+    default: v
+steps:
+- run:
+    name: generate
+    command: <<include(scripts/generate.sh)>>
+    environment:
+      ORB_PATH: << parameters.orb_path >>
+      OUTPUT: << parameters.output >>
+      FORMAT: << parameters.format >>
+      GENERATE_NAME: << parameters.generate_name >>
+      CRATE_VERSION: << parameters.crate_version >>
+      FORCE: << parameters.force >>
+      MIGRATIONS: << parameters.migrations >>
+      PRIOR_VERSIONS: << parameters.prior_versions >>
+      TAG_PREFIX: << parameters.tag_prefix >>

--- a/orb/src/commands/migrate.yml
+++ b/orb/src/commands/migrate.yml
@@ -1,0 +1,25 @@
+description: Apply conformance-based migration to a consumer's .circleci/ directory  Reads conformance rules from a JSON file (produced by `diff`) and applies them to the consumer's CI config. Reports planned changes before applying.
+parameters:
+  ci_dir:
+    type: string
+    description: Path to the consumer's .circleci/ directory
+    default: .circleci
+  orb:
+    type: string
+    description: 'The orb alias as used in the consumer''s orbs: section (e.g. "toolkit")'
+  rules:
+    type: string
+    description: Path to the conformance rules JSON file (produced by `diff`)
+  dry_run:
+    type: boolean
+    description: Show planned changes without modifying files
+    default: false
+steps:
+- run:
+    name: migrate
+    command: <<include(scripts/migrate.sh)>>
+    environment:
+      CI_DIR: << parameters.ci_dir >>
+      ORB: << parameters.orb >>
+      RULES: << parameters.rules >>
+      DRY_RUN: << parameters.dry_run >>

--- a/orb/src/commands/prime.yml
+++ b/orb/src/commands/prime.yml
@@ -1,0 +1,57 @@
+description: 'Populate prior-versions/ and migrations/ from git history  Discovers version tags in a sliding window (default: last 6 months), checks out each version, saves a snapshot to `prior-versions/<version>.yml`, and computes conformance-rule diffs to `migrations/<version>.json`. Removes files for versions outside the window to keep binary size bounded. Idempotent.'
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML entry point
+    default: src/@orb.yml
+  git_repo:
+    type: string
+    description: 'Path to the git repository root (default: walk up from orb-path to .git)'
+    default: ''
+  tag_prefix:
+    type: string
+    description: Git tag prefix (e.g. "v" matches tags like "v4.1.0")
+    default: v
+  earliest_version:
+    type: string
+    description: Fixed earliest version anchor (e.g. "4.1.0"); conflicts with --since
+    default: ''
+  since:
+    type: string
+    description: 'Rolling window duration (e.g. "6 months", "1 year"); default: "6 months"'
+    default: ''
+  prior_versions_dir:
+    type: string
+    description: Directory to write prior-version snapshots
+    default: prior-versions
+  migrations_dir:
+    type: string
+    description: Directory to write migration rule JSON files
+    default: migrations
+  ephemeral:
+    type: boolean
+    description: Write to `/tmp/gen-orb-mcp-prime-<pid>/` and print PRIME_PV_DIR/PRIME_MIG_DIR to stdout
+    default: false
+  rename_map:
+    type: string
+    description: '<OLD=NEW> Override git rename detection for a specific job (repeatable). Format: `OLD=NEW`, e.g. `--rename-map common_tests_rolling=common_tests`. Manual entries take precedence over git-detected hints for matching old names.  Use this when commits cannot be restructured to follow the two-commit rename rule'
+    default: ''
+  dry_run:
+    type: boolean
+    description: Describe actions without writing any files
+    default: false
+steps:
+- run:
+    name: prime
+    command: <<include(scripts/prime.sh)>>
+    environment:
+      ORB_PATH: << parameters.orb_path >>
+      GIT_REPO: << parameters.git_repo >>
+      TAG_PREFIX: << parameters.tag_prefix >>
+      EARLIEST_VERSION: << parameters.earliest_version >>
+      SINCE: << parameters.since >>
+      PRIOR_VERSIONS_DIR: << parameters.prior_versions_dir >>
+      MIGRATIONS_DIR: << parameters.migrations_dir >>
+      EPHEMERAL: << parameters.ephemeral >>
+      RENAME_MAP: << parameters.rename_map >>
+      DRY_RUN: << parameters.dry_run >>

--- a/orb/src/commands/publish.yml
+++ b/orb/src/commands/publish.yml
@@ -1,0 +1,25 @@
+description: Upload a compiled binary to an existing GitHub release as a release asset  The GitHub release must already exist before this command is run. Set GITHUB_TOKEN, CIRCLE_PROJECT_USERNAME, CIRCLE_PROJECT_REPONAME, and CIRCLE_TAG (or use --tag) in the environment.
+parameters:
+  binary:
+    type: string
+    description: Path to the binary file to upload
+  asset_name:
+    type: string
+    description: Name for the release asset (e.g. my-orb-mcp-linux-x86_64)
+  tag:
+    type: string
+    description: 'Release tag to publish to (default: $CIRCLE_TAG)'
+    default: ''
+  dry_run:
+    type: boolean
+    description: Describe the upload without performing it
+    default: false
+steps:
+- run:
+    name: publish
+    command: <<include(scripts/publish.sh)>>
+    environment:
+      BINARY: << parameters.binary >>
+      ASSET_NAME: << parameters.asset_name >>
+      TAG: << parameters.tag >>
+      DRY_RUN: << parameters.dry_run >>

--- a/orb/src/commands/save.yml
+++ b/orb/src/commands/save.yml
@@ -1,0 +1,39 @@
+description: 'Stage, commit, and push generated artifacts back to the repository  Idempotent: if the working tree is clean after staging the specified paths, exits successfully without creating an empty commit. The default commit message includes [skip ci] to prevent CI re-triggering.'
+parameters:
+  paths:
+    type: string
+    description: Paths to stage and commit (relative to repository root)
+  message:
+    type: string
+    description: Commit message
+    default: 'chore: update generated MCP server artifacts [skip ci]'
+  push:
+    type: enum
+    description: 'Push after committing (default: true)'
+    default: 'true'
+    enum:
+    - 'true'
+    - 'false'
+  no_push:
+    type: boolean
+    description: Stage and commit only, do not push
+    default: false
+  dry_run:
+    type: boolean
+    description: Show what would be committed without writing anything
+    default: false
+  sign:
+    type: boolean
+    description: 'Use GPG-signed commit and GitHub App token push.  Reads: BOT_GPG_KEY (base64 GPG key), BOT_TRUST (ownertrust), BOT_USER_NAME, BOT_USER_EMAIL, BOT_SIGN_KEY (key ID), GITHUB_TOKEN (GitHub App installation token), CIRCLE_PROJECT_USERNAME, CIRCLE_PROJECT_REPONAME, CIRCLE_BRANCH.'
+    default: false
+steps:
+- run:
+    name: save
+    command: <<include(scripts/save.sh)>>
+    environment:
+      PATHS: << parameters.paths >>
+      MESSAGE: << parameters.message >>
+      PUSH: << parameters.push >>
+      NO_PUSH: << parameters.no_push >>
+      DRY_RUN: << parameters.dry_run >>
+      SIGN: << parameters.sign >>

--- a/orb/src/commands/set_https_remote.yml
+++ b/orb/src/commands/set_https_remote.yml
@@ -1,0 +1,7 @@
+description: >
+  Remove the SSH insteadOf rewrite rule that CircleCI checkout injects and
+  set both the fetch and push URLs for origin to HTTPS.
+steps:
+- run:
+    name: Set HTTPS remote URLs (fetch and push)
+    command: <<include(scripts/set_https_remote.sh)>>

--- a/orb/src/commands/validate.yml
+++ b/orb/src/commands/validate.yml
@@ -1,0 +1,12 @@
+description: Validate an orb definition without generating
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML file
+    default: src/@orb.yml
+steps:
+- run:
+    name: validate
+    command: <<include(scripts/validate.sh)>>
+    environment:
+      ORB_PATH: << parameters.orb_path >>

--- a/orb/src/examples/example.yml
+++ b/orb/src/examples/example.yml
@@ -1,0 +1,10 @@
+description: >
+  Example usage of the gen-orb-mcp orb.
+usage:
+  version: 2.1
+  orbs:
+    gen-orb-mcp: jerus-org/gen-orb-mcp@1.0
+  workflows:
+    use-my-orb:
+      jobs:
+        - gen-orb-mcp/generate

--- a/orb/src/executors/default.yml
+++ b/orb/src/executors/default.yml
@@ -1,0 +1,8 @@
+description: Execution environment with gen-orb-mcp pre-installed.
+docker:
+- image: jerusdp/gen-orb-mcp:<< parameters.tag >>
+parameters:
+  tag:
+    type: string
+    description: Docker image tag.
+    default: latest

--- a/orb/src/jobs/build.yml
+++ b/orb/src/jobs/build.yml
@@ -1,0 +1,28 @@
+description: Run build command in a dedicated job.
+executor: default
+parameters:
+  input:
+    type: string
+    description: Directory containing generated MCP server source
+  attach_workspace:
+    type: boolean
+    description: Attach a workspace before running the command (use when the binary was built in a prior job).
+    default: false
+  workspace_root:
+    type: string
+    description: Path at which to attach the workspace; also prepended to PATH (only used when attach_workspace is true).
+    default: /tmp/workspace
+steps:
+- checkout
+- when:
+    condition: << parameters.attach_workspace >>
+    steps:
+    - attach_workspace:
+        at: << parameters.workspace_root >>
+    - run:
+        name: Add workspace binaries to PATH
+        command: <<include(scripts/add-workspace-to-path.sh)>>
+        environment:
+          WORKSPACE_ROOT: << parameters.workspace_root >>
+- build:
+    input: << parameters.input >>

--- a/orb/src/jobs/diff.yml
+++ b/orb/src/jobs/diff.yml
@@ -1,0 +1,41 @@
+description: Run diff command in a dedicated job.
+executor: default
+parameters:
+  current:
+    type: string
+    description: Path to the current orb YAML (the new version)
+  previous:
+    type: string
+    description: Path to the previous orb YAML (the old version to diff against)
+  since_version:
+    type: string
+    description: The version string to embed in emitted rules (e.g. "5.0.0")
+  output:
+    type: string
+    description: 'Optional output file for the JSON rules (default: stdout)'
+    default: ''
+  attach_workspace:
+    type: boolean
+    description: Attach a workspace before running the command (use when the binary was built in a prior job).
+    default: false
+  workspace_root:
+    type: string
+    description: Path at which to attach the workspace; also prepended to PATH (only used when attach_workspace is true).
+    default: /tmp/workspace
+steps:
+- checkout
+- when:
+    condition: << parameters.attach_workspace >>
+    steps:
+    - attach_workspace:
+        at: << parameters.workspace_root >>
+    - run:
+        name: Add workspace binaries to PATH
+        command: <<include(scripts/add-workspace-to-path.sh)>>
+        environment:
+          WORKSPACE_ROOT: << parameters.workspace_root >>
+- diff:
+    current: << parameters.current >>
+    previous: << parameters.previous >>
+    since_version: << parameters.since_version >>
+    output: << parameters.output >>

--- a/orb/src/jobs/generate.yml
+++ b/orb/src/jobs/generate.yml
@@ -1,0 +1,67 @@
+description: Run generate command in a dedicated job.
+executor: default
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML file (e.g., src/@orb.yml)
+    default: src/@orb.yml
+  output:
+    type: string
+    description: Output directory for generated server
+    default: ./dist
+  format:
+    type: enum
+    description: Output format
+    default: source
+    enum:
+    - binary
+    - source
+  crate_version:
+    type: string
+    description: Version for the generated MCP server crate (e.g., "1.0.0")  Required when regenerating an existing output directory. For CI workflows, this should match the orb release version.
+    default: ''
+  force:
+    type: boolean
+    description: Overwrite existing files without confirmation  Required for non-interactive CI environments when output exists.
+    default: false
+  migrations:
+    type: string
+    description: Directory containing conformance rule JSON files to embed in the server  All *.json files in this directory are merged and embedded as migration tooling in the generated server. When provided, the server gains plan_migration and apply_migration MCP Tools in addition to Resources.
+    default: ''
+  prior_versions:
+    type: string
+    description: Directory of prior orb version YAML snapshots to embed in the server  Each file should be named `<version>.yml` (e.g., `4.7.1.yml`). The generated server will expose version-specific resources for each prior version alongside the current version.
+    default: ''
+  tag_prefix:
+    type: string
+    description: Tag prefix used to discover the orb version from git tags  The git repository is derived automatically from --orb-path. Defaults to "v" (matches tags like v6.0.0).
+    default: v
+  attach_workspace:
+    type: boolean
+    description: Attach a workspace before running the command (use when the binary was built in a prior job).
+    default: false
+  workspace_root:
+    type: string
+    description: Path at which to attach the workspace; also prepended to PATH (only used when attach_workspace is true).
+    default: /tmp/workspace
+steps:
+- checkout
+- when:
+    condition: << parameters.attach_workspace >>
+    steps:
+    - attach_workspace:
+        at: << parameters.workspace_root >>
+    - run:
+        name: Add workspace binaries to PATH
+        command: <<include(scripts/add-workspace-to-path.sh)>>
+        environment:
+          WORKSPACE_ROOT: << parameters.workspace_root >>
+- generate:
+    orb_path: << parameters.orb_path >>
+    output: << parameters.output >>
+    format: << parameters.format >>
+    crate_version: << parameters.crate_version >>
+    force: << parameters.force >>
+    migrations: << parameters.migrations >>
+    prior_versions: << parameters.prior_versions >>
+    tag_prefix: << parameters.tag_prefix >>

--- a/orb/src/jobs/migrate.yml
+++ b/orb/src/jobs/migrate.yml
@@ -1,0 +1,42 @@
+description: Run migrate command in a dedicated job.
+executor: default
+parameters:
+  ci_dir:
+    type: string
+    description: Path to the consumer's .circleci/ directory
+    default: .circleci
+  orb:
+    type: string
+    description: 'The orb alias as used in the consumer''s orbs: section (e.g. "toolkit")'
+  rules:
+    type: string
+    description: Path to the conformance rules JSON file (produced by `diff`)
+  dry_run:
+    type: boolean
+    description: Show planned changes without modifying files
+    default: false
+  attach_workspace:
+    type: boolean
+    description: Attach a workspace before running the command (use when the binary was built in a prior job).
+    default: false
+  workspace_root:
+    type: string
+    description: Path at which to attach the workspace; also prepended to PATH (only used when attach_workspace is true).
+    default: /tmp/workspace
+steps:
+- checkout
+- when:
+    condition: << parameters.attach_workspace >>
+    steps:
+    - attach_workspace:
+        at: << parameters.workspace_root >>
+    - run:
+        name: Add workspace binaries to PATH
+        command: <<include(scripts/add-workspace-to-path.sh)>>
+        environment:
+          WORKSPACE_ROOT: << parameters.workspace_root >>
+- migrate:
+    ci_dir: << parameters.ci_dir >>
+    orb: << parameters.orb >>
+    rules: << parameters.rules >>
+    dry_run: << parameters.dry_run >>

--- a/orb/src/jobs/prime.yml
+++ b/orb/src/jobs/prime.yml
@@ -1,0 +1,74 @@
+description: Run prime command in a dedicated job.
+executor: default
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML entry point
+    default: src/@orb.yml
+  git_repo:
+    type: string
+    description: 'Path to the git repository root (default: walk up from orb-path to .git)'
+    default: ''
+  tag_prefix:
+    type: string
+    description: Git tag prefix (e.g. "v" matches tags like "v4.1.0")
+    default: v
+  earliest_version:
+    type: string
+    description: Fixed earliest version anchor (e.g. "4.1.0"); conflicts with --since
+    default: ''
+  since:
+    type: string
+    description: 'Rolling window duration (e.g. "6 months", "1 year"); default: "6 months"'
+    default: ''
+  prior_versions_dir:
+    type: string
+    description: Directory to write prior-version snapshots
+    default: prior-versions
+  migrations_dir:
+    type: string
+    description: Directory to write migration rule JSON files
+    default: migrations
+  ephemeral:
+    type: boolean
+    description: Write to `/tmp/gen-orb-mcp-prime-<pid>/` and print PRIME_PV_DIR/PRIME_MIG_DIR to stdout
+    default: false
+  rename_map:
+    type: string
+    description: '<OLD=NEW> Override git rename detection for a specific job (repeatable). Format: `OLD=NEW`, e.g. `--rename-map common_tests_rolling=common_tests`. Manual entries take precedence over git-detected hints for matching old names.  Use this when commits cannot be restructured to follow the two-commit rename rule'
+    default: ''
+  dry_run:
+    type: boolean
+    description: Describe actions without writing any files
+    default: false
+  attach_workspace:
+    type: boolean
+    description: Attach a workspace before running the command (use when the binary was built in a prior job).
+    default: false
+  workspace_root:
+    type: string
+    description: Path at which to attach the workspace; also prepended to PATH (only used when attach_workspace is true).
+    default: /tmp/workspace
+steps:
+- checkout
+- when:
+    condition: << parameters.attach_workspace >>
+    steps:
+    - attach_workspace:
+        at: << parameters.workspace_root >>
+    - run:
+        name: Add workspace binaries to PATH
+        command: <<include(scripts/add-workspace-to-path.sh)>>
+        environment:
+          WORKSPACE_ROOT: << parameters.workspace_root >>
+- prime:
+    orb_path: << parameters.orb_path >>
+    git_repo: << parameters.git_repo >>
+    tag_prefix: << parameters.tag_prefix >>
+    earliest_version: << parameters.earliest_version >>
+    since: << parameters.since >>
+    prior_versions_dir: << parameters.prior_versions_dir >>
+    migrations_dir: << parameters.migrations_dir >>
+    ephemeral: << parameters.ephemeral >>
+    rename_map: << parameters.rename_map >>
+    dry_run: << parameters.dry_run >>

--- a/orb/src/jobs/publish.yml
+++ b/orb/src/jobs/publish.yml
@@ -1,0 +1,42 @@
+description: Run publish command in a dedicated job.
+executor: default
+parameters:
+  binary:
+    type: string
+    description: Path to the binary file to upload
+  asset_name:
+    type: string
+    description: Name for the release asset (e.g. my-orb-mcp-linux-x86_64)
+  tag:
+    type: string
+    description: 'Release tag to publish to (default: $CIRCLE_TAG)'
+    default: ''
+  dry_run:
+    type: boolean
+    description: Describe the upload without performing it
+    default: false
+  attach_workspace:
+    type: boolean
+    description: Attach a workspace before running the command (use when the binary was built in a prior job).
+    default: false
+  workspace_root:
+    type: string
+    description: Path at which to attach the workspace; also prepended to PATH (only used when attach_workspace is true).
+    default: /tmp/workspace
+steps:
+- checkout
+- when:
+    condition: << parameters.attach_workspace >>
+    steps:
+    - attach_workspace:
+        at: << parameters.workspace_root >>
+    - run:
+        name: Add workspace binaries to PATH
+        command: <<include(scripts/add-workspace-to-path.sh)>>
+        environment:
+          WORKSPACE_ROOT: << parameters.workspace_root >>
+- publish:
+    binary: << parameters.binary >>
+    asset_name: << parameters.asset_name >>
+    tag: << parameters.tag >>
+    dry_run: << parameters.dry_run >>

--- a/orb/src/jobs/save.yml
+++ b/orb/src/jobs/save.yml
@@ -1,0 +1,57 @@
+description: Run save command in a dedicated job.
+executor: default
+parameters:
+  paths:
+    type: string
+    description: Paths to stage and commit (relative to repository root)
+  message:
+    type: string
+    description: Commit message
+    default: 'chore: update generated MCP server artifacts [skip ci]'
+  push:
+    type: enum
+    description: 'Push after committing (default: true)'
+    default: 'true'
+    enum:
+    - 'true'
+    - 'false'
+  no_push:
+    type: boolean
+    description: Stage and commit only, do not push
+    default: false
+  dry_run:
+    type: boolean
+    description: Show what would be committed without writing anything
+    default: false
+  sign:
+    type: boolean
+    description: 'Use GPG-signed commit and GitHub App token push.  Reads: BOT_GPG_KEY (base64 GPG key), BOT_TRUST (ownertrust), BOT_USER_NAME, BOT_USER_EMAIL, BOT_SIGN_KEY (key ID), GITHUB_TOKEN (GitHub App installation token), CIRCLE_PROJECT_USERNAME, CIRCLE_PROJECT_REPONAME, CIRCLE_BRANCH.'
+    default: false
+  attach_workspace:
+    type: boolean
+    description: Attach a workspace before running the command (use when the binary was built in a prior job).
+    default: false
+  workspace_root:
+    type: string
+    description: Path at which to attach the workspace; also prepended to PATH (only used when attach_workspace is true).
+    default: /tmp/workspace
+steps:
+- checkout
+- when:
+    condition: << parameters.attach_workspace >>
+    steps:
+    - attach_workspace:
+        at: << parameters.workspace_root >>
+    - run:
+        name: Add workspace binaries to PATH
+        command: <<include(scripts/add-workspace-to-path.sh)>>
+        environment:
+          WORKSPACE_ROOT: << parameters.workspace_root >>
+- set_https_remote
+- save:
+    paths: << parameters.paths >>
+    message: << parameters.message >>
+    push: << parameters.push >>
+    no_push: << parameters.no_push >>
+    dry_run: << parameters.dry_run >>
+    sign: << parameters.sign >>

--- a/orb/src/jobs/validate.yml
+++ b/orb/src/jobs/validate.yml
@@ -1,0 +1,29 @@
+description: Run validate command in a dedicated job.
+executor: default
+parameters:
+  orb_path:
+    type: string
+    description: Path to the orb YAML file
+    default: src/@orb.yml
+  attach_workspace:
+    type: boolean
+    description: Attach a workspace before running the command (use when the binary was built in a prior job).
+    default: false
+  workspace_root:
+    type: string
+    description: Path at which to attach the workspace; also prepended to PATH (only used when attach_workspace is true).
+    default: /tmp/workspace
+steps:
+- checkout
+- when:
+    condition: << parameters.attach_workspace >>
+    steps:
+    - attach_workspace:
+        at: << parameters.workspace_root >>
+    - run:
+        name: Add workspace binaries to PATH
+        command: <<include(scripts/add-workspace-to-path.sh)>>
+        environment:
+          WORKSPACE_ROOT: << parameters.workspace_root >>
+- validate:
+    orb_path: << parameters.orb_path >>

--- a/orb/src/scripts/add-workspace-to-path.sh
+++ b/orb/src/scripts/add-workspace-to-path.sh
@@ -1,0 +1,1 @@
+export PATH="${WORKSPACE_ROOT}:${PATH}"

--- a/orb/src/scripts/build.sh
+++ b/orb/src/scripts/build.sh
@@ -1,0 +1,4 @@
+set -- gen-orb-mcp build
+set -- "$@" --input "${INPUT}"
+[[ -n "${BUILD_NAME:-}" ]] && set -- "$@" --name "${BUILD_NAME}"
+"$@"

--- a/orb/src/scripts/diff.sh
+++ b/orb/src/scripts/diff.sh
@@ -1,0 +1,6 @@
+set -- gen-orb-mcp diff
+set -- "$@" --current "${CURRENT}"
+set -- "$@" --previous "${PREVIOUS}"
+set -- "$@" --since-version "${SINCE_VERSION}"
+[[ -n "${OUTPUT:-}" ]] && set -- "$@" --output "${OUTPUT}"
+"$@"

--- a/orb/src/scripts/generate.sh
+++ b/orb/src/scripts/generate.sh
@@ -1,0 +1,11 @@
+set -- gen-orb-mcp generate
+[[ -n "${ORB_PATH:-}" ]] && set -- "$@" --orb-path "${ORB_PATH}"
+[[ -n "${OUTPUT:-}" ]] && set -- "$@" --output "${OUTPUT}"
+[[ -n "${FORMAT:-}" ]] && set -- "$@" --format "${FORMAT}"
+[[ -n "${GENERATE_NAME:-}" ]] && set -- "$@" --name "${GENERATE_NAME}"
+[[ -n "${CRATE_VERSION:-}" ]] && set -- "$@" --crate-version "${CRATE_VERSION}"
+[[ "${FORCE:-false}" = "true" ]] && set -- "$@" --force
+[[ -n "${MIGRATIONS:-}" ]] && set -- "$@" --migrations "${MIGRATIONS}"
+[[ -n "${PRIOR_VERSIONS:-}" ]] && set -- "$@" --prior-versions "${PRIOR_VERSIONS}"
+[[ -n "${TAG_PREFIX:-}" ]] && set -- "$@" --tag-prefix "${TAG_PREFIX}"
+"$@"

--- a/orb/src/scripts/migrate.sh
+++ b/orb/src/scripts/migrate.sh
@@ -1,0 +1,6 @@
+set -- gen-orb-mcp migrate
+[[ -n "${CI_DIR:-}" ]] && set -- "$@" --ci-dir "${CI_DIR}"
+set -- "$@" --orb "${ORB}"
+set -- "$@" --rules "${RULES}"
+[[ "${DRY_RUN:-false}" = "true" ]] && set -- "$@" --dry-run
+"$@"

--- a/orb/src/scripts/prime.sh
+++ b/orb/src/scripts/prime.sh
@@ -1,0 +1,12 @@
+set -- gen-orb-mcp prime
+[[ -n "${ORB_PATH:-}" ]] && set -- "$@" --orb-path "${ORB_PATH}"
+[[ -n "${GIT_REPO:-}" ]] && set -- "$@" --git-repo "${GIT_REPO}"
+[[ -n "${TAG_PREFIX:-}" ]] && set -- "$@" --tag-prefix "${TAG_PREFIX}"
+[[ -n "${EARLIEST_VERSION:-}" ]] && set -- "$@" --earliest-version "${EARLIEST_VERSION}"
+[[ -n "${SINCE:-}" ]] && set -- "$@" --since "${SINCE}"
+[[ -n "${PRIOR_VERSIONS_DIR:-}" ]] && set -- "$@" --prior-versions-dir "${PRIOR_VERSIONS_DIR}"
+[[ -n "${MIGRATIONS_DIR:-}" ]] && set -- "$@" --migrations-dir "${MIGRATIONS_DIR}"
+[[ "${EPHEMERAL:-false}" = "true" ]] && set -- "$@" --ephemeral
+[[ -n "${RENAME_MAP:-}" ]] && set -- "$@" --rename-map "${RENAME_MAP}"
+[[ "${DRY_RUN:-false}" = "true" ]] && set -- "$@" --dry-run
+"$@"

--- a/orb/src/scripts/publish.sh
+++ b/orb/src/scripts/publish.sh
@@ -1,0 +1,6 @@
+set -- gen-orb-mcp publish
+set -- "$@" --binary "${BINARY}"
+set -- "$@" --asset-name "${ASSET_NAME}"
+[[ -n "${TAG:-}" ]] && set -- "$@" --tag "${TAG}"
+[[ "${DRY_RUN:-false}" = "true" ]] && set -- "$@" --dry-run
+"$@"

--- a/orb/src/scripts/save.sh
+++ b/orb/src/scripts/save.sh
@@ -1,0 +1,8 @@
+set -- gen-orb-mcp save
+set -- "$@" --paths "${PATHS}"
+[[ -n "${MESSAGE:-}" ]] && set -- "$@" --message "${MESSAGE}"
+[[ -n "${PUSH:-}" ]] && set -- "$@" --push "${PUSH}"
+[[ "${NO_PUSH:-false}" = "true" ]] && set -- "$@" --no-push
+[[ "${DRY_RUN:-false}" = "true" ]] && set -- "$@" --dry-run
+[[ "${SIGN:-false}" = "true" ]] && set -- "$@" --sign
+"$@"

--- a/orb/src/scripts/set_https_remote.sh
+++ b/orb/src/scripts/set_https_remote.sh
@@ -1,0 +1,9 @@
+# CircleCI's checkout step injects this rule into ~/.gitconfig:
+#   url."ssh://git@github.com".insteadOf = https://github.com
+# This causes git (and libgit2 used by pcu) to transparently rewrite every
+# HTTPS GitHub URL back to SSH, so git remote set-url has no observable effect
+# on the effective URL. Remove the rule before setting the remote URLs.
+git config --global --unset-all "url.ssh://git@github.com.insteadOf" 2>/dev/null || true
+HTTPS_ORIGIN="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
+git remote set-url origin "${HTTPS_ORIGIN}"
+git remote set-url --push origin "${HTTPS_ORIGIN}"

--- a/orb/src/scripts/validate.sh
+++ b/orb/src/scripts/validate.sh
@@ -1,0 +1,3 @@
+set -- gen-orb-mcp validate
+[[ -n "${ORB_PATH:-}" ]] && set -- "$@" --orb-path "${ORB_PATH}"
+"$@"


### PR DESCRIPTION
## Summary

Runs `gen-circleci-orb init` against the clean baseline (post-#174) using gen-circleci-orb v0.0.38.

**Generated:**
- 31 orb source files under `orb/src/` and `orb/Dockerfile`
- `gen-circleci-orb.toml` capturing all init settings for future re-runs

**Patched `config.yml`:**
- Added `gen-circleci-orb@0.0.38` and `orb-tools@12.3.3` orbs
- Added `build-binary` (requires `toolkit/common_tests`) and `regenerate-orb` jobs to `validation` workflow
- Added `pack-orb` and `review-orb` steps
- Added full `orb-release` tag-triggered workflow (build container, publish, build-mcp-server)

**v0.0.38 improvements reflected:**
- `git_push_subcommands = ["save"]` now in config file, not CI YAML
- `orb_path` defaults auto-injected for `generate`, `validate`, `diff` subcommands (#90)
- Config captures all context values for prompt-free re-runs (#88, #89)

## Test plan

- [ ] `validation` workflow jobs all pass
- [ ] `regenerate-orb` job produces unchanged orb source (idempotency)
- [ ] `pack-orb` and `review-orb` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)