### PR TITLE
feat(orb): rust executor image via gen-circleci-orb 0.0.43

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
 
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.38
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.43
   orb-tools: circleci/orb-tools@12.3.3
 workflows:
   validation:

--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -3,6 +3,11 @@ binary = "gen-orb-mcp"
 namespaces = ["jerus-org"]
 orb_dir = "orb"
 git_push_subcommands = ["save"]
+# build_mcp_server compiles MCP servers in this image via
+# `gen-orb-mcp generate --format binary`, so the runtime needs a Rust
+# toolchain (cargo) plus the build deps for the compiled server.
+base_image = "rust:1-slim-trixie"
+apt_packages = ["libssl-dev", "pkg-config"]
 
 [ci]
 build_workflow = "validation"

--- a/orb/Dockerfile
+++ b/orb/Dockerfile
@@ -1,12 +1,12 @@
-FROM rust:1-slim-bookworm AS builder
+FROM rust:1-slim-trixie AS builder
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/* \
     && cargo install gen-orb-mcp
 
-FROM debian:12-slim
+FROM rust:1-slim-trixie
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates git \
+    && apt-get install -y --no-install-recommends ca-certificates git libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -ms /bin/bash circleci
 COPY --from=builder /usr/local/cargo/bin/gen-orb-mcp /usr/local/bin/gen-orb-mcp


### PR DESCRIPTION
## Summary

Fixes `build-mcp-server` (which failed with `Failed to run cargo: No such file or directory`) by making the gen-orb-mcp executor image a Rust build environment again, driven entirely through generator config.

- `gen-circleci-orb.toml` `[orb]`: `base_image = "rust:1-slim-trixie"` + `apt_packages = ["libssl-dev", "pkg-config"]`
- `config.yml`: orb pin `gen-circleci-orb@0.0.38` → `@0.0.43`
- Regenerated `orb/Dockerfile` with v0.0.43 → runtime is `FROM rust:1-slim-trixie` carrying cargo + `ca-certificates git libssl-dev pkg-config`

## Why

`build_mcp_server` compiles MCP servers via `gen-orb-mcp generate --format binary`, so its executor needs cargo + build deps at runtime. PR #175's `init` had replaced the original hand-authored `rust:slim` image with the generator's minimal `debian` runtime, stripping cargo. gen-circleci-orb 0.0.43 adds `apt_packages` to config (jerus-org/gen-circleci-orb#101) and reorders `set_https_remote` before the git fetch (#100), so the image is now reproduced faithfully by the generator — no hand-authored Dockerfile, no ssh dependency.

## Verification

Regenerated locally with the v0.0.43 binary against a freshly-built `gen-orb-mcp` (matching CI): **only `orb/Dockerfile` changed** — the 30 generated job/command/script files are byte-identical between 0.0.38 and 0.0.43.

## Effect

On merge, gen-orb-mcp's orb-release rebuilds `jerusdp/gen-orb-mcp:latest` with cargo, so `build-mcp-server` compiles. This also clears gen-circleci-orb's own release `build-mcp-server` (release #640), since it runs in the same executor image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)