### PR TITLE
fix(orb): add gnupg to executor image for save --sign

### DIFF
--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -6,8 +6,11 @@ git_push_subcommands = ["save"]
 # build_mcp_server compiles MCP servers in this image via
 # `gen-orb-mcp generate --format binary`, so the runtime needs a Rust
 # toolchain (cargo) plus the build deps for the compiled server.
+# gnupg is required by `gen-orb-mcp save --sign` to import the bot GPG key
+# and create the signed commit-back. (openssh-client is not needed: git
+# uses HTTPS via set_https_remote.)
 base_image = "rust:1-slim-trixie"
-apt_packages = ["libssl-dev", "pkg-config"]
+apt_packages = ["gnupg", "libssl-dev", "pkg-config"]
 
 [ci]
 build_workflow = "validation"

--- a/orb/Dockerfile
+++ b/orb/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
 
 FROM rust:1-slim-trixie
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates git libssl-dev pkg-config \
+    && apt-get install -y --no-install-recommends ca-certificates git gnupg libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -ms /bin/bash circleci
 COPY --from=builder /usr/local/cargo/bin/gen-orb-mcp /usr/local/bin/gen-orb-mcp


### PR DESCRIPTION
## Summary

The previous fix (rust runtime + build deps) got `build-mcp-server` through **compile** and **publish** — both now pass. The final step, `gen-orb-mcp save --sign`, then failed:

```
Error: GPG import failed: gpg key import failed: sh: 1: gpg: not found
```

`save --sign` imports the bot GPG key and creates a signed commit-back, but the executor image had no `gnupg`.

## Change

Add `gnupg` to `[orb] apt_packages` and regenerate. Runtime apt set is now `ca-certificates git gnupg libssl-dev pkg-config`.

`openssh-client` (present in the original hand-authored image) is intentionally **not** re-added: git uses HTTPS via `set_https_remote`, so no ssh client is needed — the "Set up git" / "Set HTTPS remote" steps already pass without it.

## Verification

Regenerated with the v0.0.43 binary against a freshly-built gen-orb-mcp: **only `orb/Dockerfile` changed** (runtime gains `gnupg`); the 30 generated job/command/script files are byte-identical. No gen-circleci-orb release needed — `apt_packages` support is already in the pinned 0.0.43.

## Remaining original deps, accounted for

Original hand-authored set was `ca-certificates git gnupg libssl-dev openssh-client pkg-config`. Now reproduced via generator config as `ca-certificates git gnupg libssl-dev pkg-config` (+ cargo from `rust:1-slim-trixie`), dropping only `openssh-client` by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)