### PR TITLE
chore: simplify mcp executor config via gen-circleci-orb 0.0.44

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.2.0
 
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.43
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.44
   orb-tools: circleci/orb-tools@12.3.3
 workflows:
   validation:

--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -3,14 +3,8 @@ binary = "gen-orb-mcp"
 namespaces = ["jerus-org"]
 orb_dir = "orb"
 git_push_subcommands = ["save"]
-# build_mcp_server compiles MCP servers in this image via
-# `gen-orb-mcp generate --format binary`, so the runtime needs a Rust
-# toolchain (cargo) plus the build deps for the compiled server.
-# gnupg is required by `gen-orb-mcp save --sign` to import the bot GPG key
-# and create the signed commit-back. (openssh-client is not needed: git
-# uses HTTPS via set_https_remote.)
-base_image = "rust:1-slim-trixie"
-apt_packages = ["gnupg", "libssl-dev", "pkg-config"]
+# The Rust executor base and build deps (cargo, gnupg, libssl-dev, pkg-config)
+# are provisioned automatically by gen-circleci-orb because [ci].mcp = true.
 
 [ci]
 build_workflow = "validation"


### PR DESCRIPTION
## Summary

gen-circleci-orb 0.0.44 (jerus-org/gen-circleci-orb#102) auto-provisions the executor build toolchain whenever `[ci].mcp = true`. This drops the now-redundant hand-listed deps from `gen-circleci-orb.toml`:

```diff
-base_image = "rust:1-slim-trixie"
-apt_packages = ["gnupg", "libssl-dev", "pkg-config"]
```

`mcp = true` alone now provisions the Rust base + cargo + gnupg + libssl-dev + pkg-config. Orb pin bumped `0.0.43` → `0.0.44`.

## Verification

Regenerated with the 0.0.44 binary against the simplified config: **0 updated, 31 unchanged**, and `orb/Dockerfile` is **byte-identical** to the hand-listed version. So this is a pure config simplification with zero change to the generated image.

## Context

This closes the loop on the MCP executor saga: the build deps (`gnupg` for `save --sign`, `libssl-dev`/`pkg-config`/cargo for `--format binary`) are now treated as requirements of the MCP feature and provisioned by the generator — not something each consuming orb has to know about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)