### PR TITLE
chore: toolkit 6.3.0 + ignore RUSTSEC-2026-0173

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -8,4 +8,14 @@ ignore = [
     # Pulled in transitively by pcu → sigstore → json-syntax → locspan-derive.
     # Cannot be resolved without upstream pcu/sigstore patches.
     "RUSTSEC-2024-0370",
+    # RUSTSEC-2026-0173: proc-macro-error2 is unmaintained (advisory 2026-06-07).
+    # The proc-macro-error2 repo is ARCHIVED (read-only) so it will never be patched.
+    # Reaches this repo transitively, via pcu:
+    #   pcu → sigstore → oci-client → oci-spec → getset → proc-macro-error2
+    #     (getset is the blocker: no release since 2025-06; getset#132 tracks it)
+    #   pcu → gen-bsky → aquamarine → proc-macro-error2
+    #     (aquamarine is docs-only; being removed from gen-bsky in-house)
+    # Upstream tracking: jbaublitz/getset#132, youki-dev/oci-spec-rs#340.
+    # TEMPORARY — review weekly; remove once a fixed getset/oci-spec ships.
+    "RUSTSEC-2026-0173",
 ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "1.87"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
   gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.44
   orb-tools: circleci/orb-tools@12.3.3

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -11,7 +11,7 @@ parameters:
     description: "Override workspace v* version (empty = nextsv auto-detect)"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 jobs:
   tools:

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -7,7 +7,7 @@ parameters:
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 workflows:
   update_prlog:


### PR DESCRIPTION
## Summary

Two changes to get this repo's pipelines green again:

1. **Bump `jerus-org/circleci-toolkit@6.2.0 → 6.3.0`** (config.yml, release.yml, update_prlog.yml) — brings codecov orb 6.0.0, fixing the org-wide `gpg: no valid OpenPGP data found` Codecov upload failure. Also adds optional `test_runner`/`nextest` support (unused here).
2. **Ignore `RUSTSEC-2026-0173`** (`proc-macro-error2` unmaintained) in `.cargo/audit.toml`.

## On the audit ignore

`proc-macro-error2` was flagged unmaintained on 2026-06-07 and its repo is **archived** (will never be patched). It reaches this repo only transitively, via `pcu`:

- `pcu → sigstore → oci-client → oci-spec → getset → proc-macro-error2` — `getset` is the blocker (no release since 2025-06; inactive). Tracked: jbaublitz/getset#132, and we filed youki-dev/oci-spec-rs#340 asking the (active) oci-spec maintainers to drop getset.
- `pcu → gen-bsky → aquamarine → proc-macro-error2` — `aquamarine` is a docs-only macro; its removal from gen-bsky is tracked as a separate in-house fix.

The ignore is **temporary and documented** (path, rationale, upstream links, weekly-review note) and will be removed as soon as a fixed `getset`/`oci-spec` ships. Both fixes are needed together — without 6.3.0 the codecov step fails, and without the ignore the security step fails.

## Effect

Restores both the Codecov upload and the security/audit step to green. After merge, PR #181 (publish/save CLI) needs only a rebase to clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
