### PR TITLE
feat: export build_mcp_server as a composed job_group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.3.0
 
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.45
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.46
   orb-tools: circleci/orb-tools@12.3.3
 workflows:
   validation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.3.0
 
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.44
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.45
   orb-tools: circleci/orb-tools@12.3.3
 workflows:
   validation:

--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -25,3 +25,114 @@ mcp_earliest_version = "0.1.11"
 
 [subcommand.help]
 generate_job = false
+
+# build_mcp_server: a goal-oriented composite job assembled from this orb's own
+# commands (set_https_remote, prime, generate, publish, save) plus a small git
+# setup step. It primes prior-version snapshots, generates and compiles the MCP
+# server, publishes the binary to the GitHub release, and commits the generated
+# artifacts back to main.
+#
+# Runs in the orb's `default` executor (the gen-orb-mcp image). When invoked
+# with attach_workspace=true it uses a freshly-built binary attached at
+# workspace_root (so a release dogfoods its own build); otherwise it falls back
+# to the gen-orb-mcp already installed in the image.
+[[job_group]]
+name = "build_mcp_server"
+description = "Prime, generate, compile, publish and commit back the MCP server (composed from the orb's own commands)."
+
+[[job_group.parameter]]
+name = "binary_name"
+description = "Orb binary name (e.g. gen-orb-mcp); names the generated MCP server and release asset."
+
+[[job_group.parameter]]
+name = "tag_prefix"
+description = "Git tag prefix for VERSION extraction and prime scoping (e.g. gen-orb-mcp-v)."
+
+[[job_group.parameter]]
+name = "orb_path"
+default = "orb/src/@orb.yml"
+description = "Path to the orb source @orb.yml."
+
+[[job_group.parameter]]
+name = "earliest_version"
+description = "Earliest orb version to include when priming prior-version snapshots."
+
+[[job_group.parameter]]
+name = "prior_versions_dir"
+default = "prior-versions"
+description = "Directory for prior-version snapshots."
+
+[[job_group.parameter]]
+name = "migrations_dir"
+default = "migrations"
+description = "Directory for migration rule files."
+
+[[job_group.step]]
+builtin = "checkout"
+
+[[job_group.step]]
+builtin = "attach_workspace"
+
+[[job_group.step]]
+command = "set_https_remote"
+
+[[job_group.step]]
+run = "Set up git and environment"
+script = '''
+# Use the freshly-built binary if it was attached from the workspace,
+# otherwise fall back to the gen-orb-mcp installed in the image.
+if [ -f "${WORKSPACE_BIN_PATH}/${NAME}" ]; then
+  chmod +x "${WORKSPACE_BIN_PATH}/${NAME}"
+  echo "export PATH=${WORKSPACE_BIN_PATH}:\$PATH" >> "$BASH_ENV"
+fi
+VERSION="${CIRCLE_TAG#${TAG_PREFIX}}"
+echo "export VERSION=${VERSION}" >> "$BASH_ENV"
+echo "export CIRCLE_BRANCH=main" >> "$BASH_ENV"
+git fetch origin main
+git checkout -B main origin/main
+'''
+
+[job_group.step.environment]
+NAME = "<< parameters.binary_name >>"
+TAG_PREFIX = "<< parameters.tag_prefix >>"
+WORKSPACE_BIN_PATH = "<< parameters.workspace_root >>"
+
+[[job_group.step]]
+command = "prime"
+
+[job_group.step.with]
+orb_path = "<< parameters.orb_path >>"
+tag_prefix = "<< parameters.tag_prefix >>"
+earliest_version = "<< parameters.earliest_version >>"
+
+[[job_group.step]]
+command = "generate"
+
+# crate_version is intentionally omitted: gen-orb-mcp generate auto-resolves it
+# from the latest tag matching tag_prefix, and a runtime $VERSION cannot be
+# threaded through an orb parameter.
+[job_group.step.with]
+format = "binary"
+generate_name = "<< parameters.binary_name >>"
+orb_path = "<< parameters.orb_path >>"
+output = "/tmp/mcp-server"
+force = "true"
+prior_versions = "<< parameters.prior_versions_dir >>"
+migrations = "<< parameters.migrations_dir >>"
+
+[[job_group.step]]
+command = "publish"
+
+# publish derives the binary path and asset name from the orb name + input dir
+# (gen-orb-mcp >= 0.1.38); --tag defaults to $CIRCLE_TAG.
+[job_group.step.with]
+publish_name = "<< parameters.binary_name >>"
+input = "/tmp/mcp-server"
+
+[[job_group.step]]
+command = "save"
+
+# save accepts comma-separated paths (gen-orb-mcp >= 0.1.38).
+[job_group.step.with]
+paths = "<< parameters.prior_versions_dir >>,<< parameters.migrations_dir >>"
+sign = "true"

--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -81,7 +81,7 @@ run = "Set up git and environment"
 script = '''
 # Use the freshly-built binary if it was attached from the workspace,
 # otherwise fall back to the gen-orb-mcp installed in the image.
-if [ -f "${WORKSPACE_BIN_PATH}/${NAME}" ]; then
+if [[ -f "${WORKSPACE_BIN_PATH}/${NAME}" ]]; then
   chmod +x "${WORKSPACE_BIN_PATH}/${NAME}"
   echo "export PATH=${WORKSPACE_BIN_PATH}:\$PATH" >> "$BASH_ENV"
 fi

--- a/orb/src/commands/publish.yml
+++ b/orb/src/commands/publish.yml
@@ -1,11 +1,21 @@
 description: Upload a compiled binary to an existing GitHub release as a release asset  The GitHub release must already exist before this command is run. Set GITHUB_TOKEN, CIRCLE_PROJECT_USERNAME, CIRCLE_PROJECT_REPONAME, and CIRCLE_TAG (or use --tag) in the environment.
 parameters:
+  publish_name:
+    type: string
+    description: 'Orb binary base name (e.g. "gen-orb-mcp"). Derives the binary path and asset name when --binary / --asset-name are not given: binary = <input>/target/release/<name_underscored>_mcp asset  = <name_underscored>_mcp-linux-x86_64'
+    default: ''
+  input:
+    type: string
+    description: Directory containing the compiled `target/release` (used with --name)
+    default: ./dist
   binary:
     type: string
-    description: Path to the binary file to upload
+    description: Path to the binary file to upload (overrides derivation from --name)
+    default: ''
   asset_name:
     type: string
-    description: Name for the release asset (e.g. my-orb-mcp-linux-x86_64)
+    description: Name for the release asset, e.g. my-orb-mcp-linux-x86_64 (overrides derivation from --name)
+    default: ''
   tag:
     type: string
     description: 'Release tag to publish to (default: $CIRCLE_TAG)'
@@ -19,6 +29,8 @@ steps:
     name: publish
     command: <<include(scripts/publish.sh)>>
     environment:
+      PUBLISH_NAME: << parameters.publish_name >>
+      INPUT: << parameters.input >>
       BINARY: << parameters.binary >>
       ASSET_NAME: << parameters.asset_name >>
       TAG: << parameters.tag >>

--- a/orb/src/commands/save.yml
+++ b/orb/src/commands/save.yml
@@ -2,7 +2,7 @@ description: 'Stage, commit, and push generated artifacts back to the repository
 parameters:
   paths:
     type: string
-    description: Paths to stage and commit (relative to repository root)
+    description: Paths to stage and commit (relative to repository root).  Repeatable (`--paths a --paths b`) or comma-separated (`--paths a,b`) so a single orb parameter can carry multiple paths.
   message:
     type: string
     description: Commit message

--- a/orb/src/jobs/build_mcp_server.yml
+++ b/orb/src/jobs/build_mcp_server.yml
@@ -45,18 +45,7 @@ steps:
 - set_https_remote
 - run:
     name: Set up git and environment
-    command: |
-      # Use the freshly-built binary if it was attached from the workspace,
-      # otherwise fall back to the gen-orb-mcp installed in the image.
-      if [ -f "${WORKSPACE_BIN_PATH}/${NAME}" ]; then
-        chmod +x "${WORKSPACE_BIN_PATH}/${NAME}"
-        echo "export PATH=${WORKSPACE_BIN_PATH}:\$PATH" >> "$BASH_ENV"
-      fi
-      VERSION="${CIRCLE_TAG#${TAG_PREFIX}}"
-      echo "export VERSION=${VERSION}" >> "$BASH_ENV"
-      echo "export CIRCLE_BRANCH=main" >> "$BASH_ENV"
-      git fetch origin main
-      git checkout -B main origin/main
+    command: <<include(scripts/build_mcp_server_set_up_git_and_environment.sh)>>
     environment:
       NAME: << parameters.binary_name >>
       TAG_PREFIX: << parameters.tag_prefix >>

--- a/orb/src/jobs/build_mcp_server.yml
+++ b/orb/src/jobs/build_mcp_server.yml
@@ -1,0 +1,81 @@
+description: Prime, generate, compile, publish and commit back the MCP server (composed from the orb's own commands).
+executor: default
+parameters:
+  binary_name:
+    type: string
+    description: Orb binary name (e.g. gen-orb-mcp); names the generated MCP server and release asset.
+  tag_prefix:
+    type: string
+    description: Git tag prefix for VERSION extraction and prime scoping (e.g. gen-orb-mcp-v).
+  orb_path:
+    type: string
+    description: Path to the orb source @orb.yml.
+    default: orb/src/@orb.yml
+  earliest_version:
+    type: string
+    description: Earliest orb version to include when priming prior-version snapshots.
+  prior_versions_dir:
+    type: string
+    description: Directory for prior-version snapshots.
+    default: prior-versions
+  migrations_dir:
+    type: string
+    description: Directory for migration rule files.
+    default: migrations
+  attach_workspace:
+    type: boolean
+    description: Attach a workspace before running the command (use when the binary was built in a prior job).
+    default: false
+  workspace_root:
+    type: string
+    description: Path at which to attach the workspace; also prepended to PATH (only used when attach_workspace is true).
+    default: /tmp/workspace
+steps:
+- checkout
+- when:
+    condition: << parameters.attach_workspace >>
+    steps:
+    - attach_workspace:
+        at: << parameters.workspace_root >>
+    - run:
+        name: Add workspace binaries to PATH
+        command: <<include(scripts/add-workspace-to-path.sh)>>
+        environment:
+          WORKSPACE_ROOT: << parameters.workspace_root >>
+- set_https_remote
+- run:
+    name: Set up git and environment
+    command: |
+      # Use the freshly-built binary if it was attached from the workspace,
+      # otherwise fall back to the gen-orb-mcp installed in the image.
+      if [ -f "${WORKSPACE_BIN_PATH}/${NAME}" ]; then
+        chmod +x "${WORKSPACE_BIN_PATH}/${NAME}"
+        echo "export PATH=${WORKSPACE_BIN_PATH}:\$PATH" >> "$BASH_ENV"
+      fi
+      VERSION="${CIRCLE_TAG#${TAG_PREFIX}}"
+      echo "export VERSION=${VERSION}" >> "$BASH_ENV"
+      echo "export CIRCLE_BRANCH=main" >> "$BASH_ENV"
+      git fetch origin main
+      git checkout -B main origin/main
+    environment:
+      NAME: << parameters.binary_name >>
+      TAG_PREFIX: << parameters.tag_prefix >>
+      WORKSPACE_BIN_PATH: << parameters.workspace_root >>
+- prime:
+    orb_path: << parameters.orb_path >>
+    tag_prefix: << parameters.tag_prefix >>
+    earliest_version: << parameters.earliest_version >>
+- generate:
+    format: binary
+    generate_name: << parameters.binary_name >>
+    orb_path: << parameters.orb_path >>
+    output: /tmp/mcp-server
+    force: true
+    prior_versions: << parameters.prior_versions_dir >>
+    migrations: << parameters.migrations_dir >>
+- publish:
+    publish_name: << parameters.binary_name >>
+    input: /tmp/mcp-server
+- save:
+    paths: << parameters.prior_versions_dir >>,<< parameters.migrations_dir >>
+    sign: true

--- a/orb/src/jobs/publish.yml
+++ b/orb/src/jobs/publish.yml
@@ -1,12 +1,18 @@
 description: Run publish command in a dedicated job.
 executor: default
 parameters:
+  input:
+    type: string
+    description: Directory containing the compiled `target/release` (used with --name)
+    default: ./dist
   binary:
     type: string
-    description: Path to the binary file to upload
+    description: Path to the binary file to upload (overrides derivation from --name)
+    default: ''
   asset_name:
     type: string
-    description: Name for the release asset (e.g. my-orb-mcp-linux-x86_64)
+    description: Name for the release asset, e.g. my-orb-mcp-linux-x86_64 (overrides derivation from --name)
+    default: ''
   tag:
     type: string
     description: 'Release tag to publish to (default: $CIRCLE_TAG)'
@@ -36,6 +42,7 @@ steps:
         environment:
           WORKSPACE_ROOT: << parameters.workspace_root >>
 - publish:
+    input: << parameters.input >>
     binary: << parameters.binary >>
     asset_name: << parameters.asset_name >>
     tag: << parameters.tag >>

--- a/orb/src/jobs/save.yml
+++ b/orb/src/jobs/save.yml
@@ -3,7 +3,7 @@ executor: default
 parameters:
   paths:
     type: string
-    description: Paths to stage and commit (relative to repository root)
+    description: Paths to stage and commit (relative to repository root).  Repeatable (`--paths a --paths b`) or comma-separated (`--paths a,b`) so a single orb parameter can carry multiple paths.
   message:
     type: string
     description: Commit message

--- a/orb/src/scripts/build_mcp_server_set_up_git_and_environment.sh
+++ b/orb/src/scripts/build_mcp_server_set_up_git_and_environment.sh
@@ -1,6 +1,6 @@
 # Use the freshly-built binary if it was attached from the workspace,
 # otherwise fall back to the gen-orb-mcp installed in the image.
-if [ -f "${WORKSPACE_BIN_PATH}/${NAME}" ]; then
+if [[ -f "${WORKSPACE_BIN_PATH}/${NAME}" ]]; then
   chmod +x "${WORKSPACE_BIN_PATH}/${NAME}"
   echo "export PATH=${WORKSPACE_BIN_PATH}:\$PATH" >> "$BASH_ENV"
 fi

--- a/orb/src/scripts/build_mcp_server_set_up_git_and_environment.sh
+++ b/orb/src/scripts/build_mcp_server_set_up_git_and_environment.sh
@@ -1,0 +1,11 @@
+# Use the freshly-built binary if it was attached from the workspace,
+# otherwise fall back to the gen-orb-mcp installed in the image.
+if [ -f "${WORKSPACE_BIN_PATH}/${NAME}" ]; then
+  chmod +x "${WORKSPACE_BIN_PATH}/${NAME}"
+  echo "export PATH=${WORKSPACE_BIN_PATH}:\$PATH" >> "$BASH_ENV"
+fi
+VERSION="${CIRCLE_TAG#${TAG_PREFIX}}"
+echo "export VERSION=${VERSION}" >> "$BASH_ENV"
+echo "export CIRCLE_BRANCH=main" >> "$BASH_ENV"
+git fetch origin main
+git checkout -B main origin/main

--- a/orb/src/scripts/publish.sh
+++ b/orb/src/scripts/publish.sh
@@ -1,6 +1,8 @@
 set -- gen-orb-mcp publish
-set -- "$@" --binary "${BINARY}"
-set -- "$@" --asset-name "${ASSET_NAME}"
+[[ -n "${PUBLISH_NAME:-}" ]] && set -- "$@" --name "${PUBLISH_NAME}"
+[[ -n "${INPUT:-}" ]] && set -- "$@" --input "${INPUT}"
+[[ -n "${BINARY:-}" ]] && set -- "$@" --binary "${BINARY}"
+[[ -n "${ASSET_NAME:-}" ]] && set -- "$@" --asset-name "${ASSET_NAME}"
 [[ -n "${TAG:-}" ]] && set -- "$@" --tag "${TAG}"
 [[ "${DRY_RUN:-false}" = "true" ]] && set -- "$@" --dry-run
 "$@"


### PR DESCRIPTION
## Summary

**Phase 3** of moving `build_mcp_server` out of gen-circleci-orb and into gen-orb-mcp: this orb now **exports `gen-orb-mcp/build_mcp_server`** as a goal-oriented composite `[[job_group]]` assembled entirely from its **own commands** (`set_https_remote`, `prime`, `generate`, `publish`, `save`) plus one small git-setup `run` step. No MCP-specific logic is embedded in the gen-circleci-orb generator — it's all declared as data in `gen-circleci-orb.toml`.

## Changes

- **`gen-circleci-orb.toml`**: new `[[job_group]] build_mcp_server` (params + ordered steps).
- **pin bump** `gen-circleci-orb@0.0.44 → 0.0.45` (the rich job_group renderer).
- **regenerated orb** against gen-orb-mcp v0.1.38, which also updates:
  - `publish` → gains `publish_name` + `input` (derives binary path + asset name from the orb name; `--tag` defaults to `$CIRCLE_TAG`).
  - `save` → comma-separated `paths` (`prior-versions,migrations` in one call).
  - `generate` → `crate_version` omitted (auto-resolved from the release tag; a runtime `$VERSION` can't thread through an orb param).
- **new** `orb/src/jobs/build_mcp_server.yml` (the emitted composite job).

## Conditional fresh-binary

The job runs in the orb's `default` executor (the gen-orb-mcp image). With `attach_workspace=true` it uses a binary built earlier in the pipeline (a gen-orb-mcp release dogfoods its own build); the setup step falls back to the image's `gen-orb-mcp` if no binary was attached — so the **same job is reusable by any orb** that adopts `gen-orb-mcp`.

## Notes

- `release.yml` still invokes `gen-circleci-orb/build_mcp_server` for **this** release (it can't self-reference the version being published). A follow-up flips it to `gen-orb-mcp/build_mcp_server` once this publishes.
- Validated locally: `circleci orb pack orb/src` succeeds; the emitted job references the correct command params. CI's `regenerate-orb` re-runs for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
