### PR TITLE
chore: self-host build_mcp_server + CI corrections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ orbs:
   toolkit: jerus-org/circleci-toolkit@6.3.0
 
   gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.46
+  gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.39
   orb-tools: circleci/orb-tools@12.3.3
 workflows:
   validation:
@@ -60,7 +61,6 @@ workflows:
           filters:
             branches:
               only:
-                - main
                 - /pull\/[0-9]+/
 
       - toolkit/security:
@@ -70,7 +70,6 @@ workflows:
             branches:
               ignore:
                 - /pull\/[0-9]+/
-                - main
 
       - toolkit/code_coverage:
           context: SonarCloud
@@ -175,12 +174,15 @@ workflows:
             branches:
               ignore: /.*/
 
-      - gen-circleci-orb/build_mcp_server:
+      - gen-orb-mcp/build_mcp_server:
           name: build-mcp-server
           binary_name: gen-orb-mcp
           tag_prefix: gen-orb-mcp-v
           orb_path: orb/src/@orb.yml
           earliest_version: "0.1.11"
+          # Attach the freshly-built binary so the release dogfoods its own build.
+          attach_workspace: true
+          workspace_root: /tmp/bin
           requires: [publish-orb-jerus-org]
           context: [release, bot-check, pcu-app]
           filters:

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -22,7 +22,3 @@ workflows:
           pcu_from_merge: --from-merge
           update_pcu: << pipeline.parameters.update_pcu >>
           pcu_verbosity: "-vvv"
-      - toolkit/label:
-          context: pcu-app
-          requires:
-            - update-prlog-on-main


### PR DESCRIPTION
## Summary

**Cutover** to the self-hosted composite job, plus two standing CI-config corrections.

### 1. Self-host `build_mcp_server`
Now that `jerus-org/gen-orb-mcp@0.1.39` exports `build_mcp_server`, the `orb-release` workflow invokes **`gen-orb-mcp/build_mcp_server`** (the orb's own composed job) instead of `gen-circleci-orb/build_mcp_server`:
- Added `gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.39` to `orbs`.
- Switched the invocation; pinning one orb version now fixes **both** the job definition *and* its executor image tag (reproducible).
- `attach_workspace: true` + `workspace_root: /tmp/bin` so the release dogfoods its freshly-built binary (the conditional setup step uses it when attached, else the image's `gen-orb-mcp`).

### 2. Security runs with sonarcloud on main
Previously "security audit only" (`sonarcloud: false`) ran on `main`, so **SonarCloud never updated on main pushes**. Now:
- audit-only → forked PRs only (`/pull\/[0-9]+/`).
- with-sonarcloud → everything else incl. `main`.

### 3. Drop redundant `label` job
Removed the standalone `toolkit/label` job from the `update_prlog` workflow — labeling is already done by `toolkit/update_prlog`.

## Validation
`circleci config validate` passes for both `config.yml` (the `gen-orb-mcp@0.1.39` self-reference resolves) and `update_prlog.yml`.

## Follow-up (gen-circleci-orb)
- `ci_patcher`: repoint generated consumer release configs from `gen-circleci-orb/build_mcp_server` → `gen-orb-mcp/build_mcp_server` (+ orbs entry).
- Delete the now-obsolete hand-authored `build_mcp_server.yml` + 5 scripts from gen-circleci-orb's orb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)