### PR TITLE
fix: build_mcp_server generate uses crate version

### DIFF
--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -110,7 +110,8 @@ command = "generate"
 
 # crate_version is intentionally omitted: gen-orb-mcp generate auto-resolves it
 # from the latest tag matching tag_prefix, and a runtime $VERSION cannot be
-# threaded through an orb parameter.
+# threaded through an orb parameter. tag_prefix MUST be passed so it resolves
+# the crate tag (gen-orb-mcp-v*) and not the workspace/repo tag (v*).
 [job_group.step.with]
 format = "binary"
 generate_name = "<< parameters.binary_name >>"
@@ -119,6 +120,7 @@ output = "/tmp/mcp-server"
 force = "true"
 prior_versions = "<< parameters.prior_versions_dir >>"
 migrations = "<< parameters.migrations_dir >>"
+tag_prefix = "<< parameters.tag_prefix >>"
 
 [[job_group.step]]
 command = "publish"

--- a/orb/src/jobs/build_mcp_server.yml
+++ b/orb/src/jobs/build_mcp_server.yml
@@ -62,6 +62,7 @@ steps:
     force: true
     prior_versions: << parameters.prior_versions_dir >>
     migrations: << parameters.migrations_dir >>
+    tag_prefix: << parameters.tag_prefix >>
 - publish:
     publish_name: << parameters.binary_name >>
     input: /tmp/mcp-server


### PR DESCRIPTION
## Problem

The `build_mcp_server` composite job's `generate` step omitted `tag_prefix`. As a result, `gen-orb-mcp generate` fell back to the default prefix `"v"` and auto-resolved the **workspace/repo** tag (`v*`) instead of the **crate** tag (`gen-orb-mcp-v*`) when determining the version to stamp into the generated MCP server.

So the generated server carried the repo/workspace version, not the version of the `gen-orb-mcp` crate it was built from.

## Fix

Pass `tag_prefix = << parameters.tag_prefix >>` to the `generate` step (matching the existing `prime` step) in both:
- `gen-circleci-orb.toml` (the job-group source of truth)
- `orb/src/jobs/build_mcp_server.yml` (regenerated output)

`gen-orb-mcp generate` then resolves the latest `gen-orb-mcp-v*` tag.

## Version resolution is correctly anchored

`primer::discover_tags` matches via `git tag -l "{prefix}*"` (start-anchored) **plus** a `tag.starts_with(tag_prefix)` filter, so:
- `gen-orb-mcp-v` matches only crate tags;
- `v` never matches `gen-orb-mcp-v…` (those start with `g`).

The unanchored-regex class of bug (nextsv #443) does **not** apply here — no anchoring change needed.

## Validation

- `circleci orb pack orb/src` → exit 0; packed `generate` step now emits `--tag-prefix "${TAG_PREFIX}"` with `TAG_PREFIX: << parameters.tag_prefix >>`.

Non-Rust orb change (TOML + generated YAML); no crate code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
