### PR TITLE
chore: pin build_mcp_server orb to gen-orb-mcp@0.1.42

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
   toolkit: jerus-org/circleci-toolkit@6.3.0
 
   gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.46
-  gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.39
+  gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.42
   orb-tools: circleci/orb-tools@12.3.3
 workflows:
   validation:


### PR DESCRIPTION
## What

Pin the self-referential `build_mcp_server` orb from `gen-orb-mcp@0.1.39` → `@0.1.42`.

## Why

`build_mcp_server` runs in the **pinned orb's executor image** (`jerusdp/gen-orb-mcp:<pinned>`), not the freshly-built `/tmp` binary — CI should run on a stable, released tool.

The previous pin (`0.1.39`) predates the `save --sign` git-identity fix (#187), so the `save` step ran the **stale 0.1.39 image binary** and failed with:

```
Error: config value 'user.name' was not found; class=Config (7); code=NotFound (-3)
```

Confirmed via CI logs (job 6805, the 0.1.42 release): `publish` succeeded, `save` failed with the above — i.e. #187 was merged into the binary but **never actually ran in CI**, because the pinned image was older.

`0.1.42`'s image carries #187 (writes the git identity to the global config in `setup_git_identity`). Pinning to `0.1.42` makes the **next** release's `save` step run the fixed binary — validating #187 in CI.

## Follow-up

#188's `generate` `tag_prefix` fix (crate-version resolution) lands in the **0.1.43** orb job definition. A follow-up pin bump to `0.1.43` will validate that on the subsequent cycle.

## Validation

- `circleci config validate --org-slug gh/jerus-org` → valid (resolves `gen-orb-mcp@0.1.42`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
