### PR TITLE
chore: pin build_mcp_server orb to gen-orb-mcp@0.1.44

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
   toolkit: jerus-org/circleci-toolkit@6.3.0
 
   gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.47
-  gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.43
+  gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.44
   orb-tools: circleci/orb-tools@12.4.0
 workflows:
   validation:


### PR DESCRIPTION
## What

Pin `build_mcp_server` from `gen-orb-mcp@0.1.43` → `@0.1.44`.

## Why

`build_mcp_server` runs in the **pinned orb's executor image**. The `save` step in the latest release (pipeline #1198) failed with:

```
Error: config value 'user.name' was not found; class=Config (7); code=NotFound (-3)
```

`0.1.43`'s image predates the explicit-identity save fix (#195) — it still uses `setup_git_identity`, which writes the identity to git config, and that read fails in CI (`safe.directory` / dubious ownership).

`0.1.44`'s image carries **#195**: `save` passes the commit identity and GPG signing key to pcu **explicitly** via `SignConfig::with_identity`/`with_signing_key` (pcu 0.6.22) — no git config involved — so the step works regardless of config visibility.

## Validation

- `circleci config validate --org-slug gh/jerus-org` → valid (resolves `gen-orb-mcp@0.1.44`).

## Note

The short step names (`prime`/`generate`/`save`) are a **separate** issue — they need curated labels + an orb regen with gen-circleci-orb 0.0.47 (#106); tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
