### PR TITLE
feat: curated run-step labels for orb commands

### DIFF
--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -26,6 +26,21 @@ mcp_earliest_version = "0.1.11"
 [subcommand.help]
 generate_job = false
 
+# Curated, human-readable run-step names for the orb commands (used by
+# build_mcp_server's steps and the standalone command jobs). Without these the
+# generator falls back to each command's short --help line, then the bare name.
+[subcommand.prime]
+label = "Prime prior versions and migrations"
+
+[subcommand.generate]
+label = "Generate and compile MCP server"
+
+[subcommand.publish]
+label = "Publish MCP server binary to GitHub release"
+
+[subcommand.save]
+label = "Commit back generated artifacts"
+
 # build_mcp_server: a goal-oriented composite job assembled from this orb's own
 # commands (set_https_remote, prime, generate, publish, save) plus a small git
 # setup step. It primes prior-version snapshots, generates and compiles the MCP


### PR DESCRIPTION
## What

Add curated `[subcommand.*] label` entries to `gen-circleci-orb.toml` so the orb command steps render with human-readable names instead of the bare subcommand name.

```toml
[subcommand.prime]
label = "Prime prior versions and migrations"
[subcommand.generate]
label = "Generate and compile MCP server"
[subcommand.publish]
label = "Publish MCP server binary to GitHub release"
[subcommand.save]
label = "Commit back generated artifacts"
```

Uses the gen-circleci-orb **0.0.47** label support (#106), which is already pinned in `config.yml`.

## Why

In `build_mcp_server` the steps currently show as `prime` / `generate` / `publish` / `save` — blunt next to the descriptive steps around them.

## Validation

Regenerated the orb locally with gen-circleci-orb 0.0.47 + the gen-orb-mcp binary; the generated command run-steps become:

| command | run-step name |
|---|---|
| prime | Prime prior versions and migrations |
| generate | Generate and compile MCP server |
| publish | Publish MCP server binary to GitHub release |
| save | Commit back generated artifacts |

(The other commands — build/diff/migrate/validate — also pick up descriptive names via #106's short-about fallback.)

Only the toml is committed; CI's `regenerate-orb` job regenerates `orb/src/` (with proper Dockerfile digest pinning) on the next build.

## When the names appear

The step names come from the **pinned** orb, so this takes effect once:
1. this merges → CI regenerates `orb/src/` with the labels,
2. a new gen-orb-mcp release packages that orb (e.g. 0.1.45),
3. `build_mcp_server`'s pin is bumped to that release.

(Separate from #197, which bumps the pin to 0.1.44 for the `save` fix; the names need the subsequent release + pin bump.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
