### PR TITLE
fix: build_mcp_server runs stable image, not /tmp binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,9 +180,11 @@ workflows:
           tag_prefix: gen-orb-mcp-v
           orb_path: orb/src/@orb.yml
           earliest_version: "0.1.11"
-          # Attach the freshly-built binary so the release dogfoods its own build.
-          attach_workspace: true
-          workspace_root: /tmp/bin
+          # Run the stable pinned-orb image binary (no /tmp/bin override). The
+          # attached workspace binary shadowed the image's gen-orb-mcp on PATH,
+          # and a stale (pre-explicit-identity) cached build there made `save`
+          # fail with "user.name not found". The pinned image binary uses the
+          # explicit-identity path and commits cleanly.
           requires: [publish-orb-jerus-org]
           context: [release, bot-check, pcu-app]
           filters:


### PR DESCRIPTION
## Problem

The `save` step of `build_mcp_server` keeps failing with:

```
Error: config value 'user.name' was not found; class=Config (7); code=NotFound (-3)
```

even though the pin was bumped to `gen-orb-mcp@0.1.44`, whose image binary has the explicit-identity fix (#195).

## Root cause

`build_mcp_server` was invoked with `attach_workspace: true` + `workspace_root: /tmp/bin`. The "Add workspace binaries to PATH" step prepends `/tmp/bin` **ahead of** the image's `/usr/local/bin/gen-orb-mcp`. So `save` runs the **workspace** binary (from `build_rust_binary`'s cached cargo build), not the image binary — and that cached binary is stale (pre-explicit-identity), so it still takes the old `git_repo.signature()` path → `user.name not found`.

`prime`/`generate`/`publish` succeed because they're version-agnostic; only `save` exercises the identity path, so only it exposes the stale binary.

The executor image itself is correct — the published `gen-orb-mcp@0.1.44` orb references `jerusdp/gen-orb-mcp:0.1.44` (executor `tag` default `0.1.44`), and that image's binary is `gen-orb-mcp 0.1.44` with #195.

## Fix

Remove the `/tmp/bin` override so `save` runs the **stable pinned-orb image binary** (matching the "CI should run on a stable gen-orb-mcp" principle).

## Verification (podman, 0.1.44 image)

Ran `gen-orb-mcp save --sign` in the 0.1.44 image, on a repo with **no** `user.name`/`user.email` in git config, with an ephemeral GPG key:

```
Created signed commit: chore: update generated MCP server artifacts [skip ci]
SAVE_EXIT=0
commit: author=Test Bot <bot@example.com>  sig=G  key=...
~/.gitconfig after run: (none)   # no setup_git_identity; explicit-identity path
```

GPG-signed, identity from `BOT_*` env (not git config), exit 0 — no `user.name not found`.

## Validation

- `circleci config validate --org-slug gh/jerus-org` → valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
