### PR TITLE
fix: curated run-step names in committed orb command files

### DIFF
--- a/orb/src/commands/generate.yml
+++ b/orb/src/commands/generate.yml
@@ -41,7 +41,7 @@ parameters:
     default: v
 steps:
 - run:
-    name: generate
+    name: Generate and compile MCP server
     command: <<include(scripts/generate.sh)>>
     environment:
       ORB_PATH: << parameters.orb_path >>

--- a/orb/src/commands/prime.yml
+++ b/orb/src/commands/prime.yml
@@ -42,7 +42,7 @@ parameters:
     default: false
 steps:
 - run:
-    name: prime
+    name: Prime prior versions and migrations
     command: <<include(scripts/prime.sh)>>
     environment:
       ORB_PATH: << parameters.orb_path >>

--- a/orb/src/commands/publish.yml
+++ b/orb/src/commands/publish.yml
@@ -26,7 +26,7 @@ parameters:
     default: false
 steps:
 - run:
-    name: publish
+    name: Publish MCP server binary to GitHub release
     command: <<include(scripts/publish.sh)>>
     environment:
       PUBLISH_NAME: << parameters.publish_name >>

--- a/orb/src/commands/save.yml
+++ b/orb/src/commands/save.yml
@@ -28,7 +28,7 @@ parameters:
     default: false
 steps:
 - run:
-    name: save
+    name: Commit back generated artifacts
     command: <<include(scripts/save.sh)>>
     environment:
       PATHS: << parameters.paths >>


### PR DESCRIPTION
## Problem

`build_mcp_server`'s steps render with bare names (`prime`, `generate`, `publish`, `save`). #198 added curated `[subcommand.*]` labels to `gen-circleci-orb.toml`, but they never appeared — because **`orb-release` packs the committed `orb/src` with no regeneration step** (`orb-release-pack` = `orb-tools/pack source_dir: orb/src`, only sed-injecting the executor tag). The committed command files were stale/bare, so the published orb stayed bare.

## Fix

Apply the curated names directly to the committed command files — exactly what the gen-circleci-orb 0.0.47 generator produces from the `[subcommand.*]` labels:

| command | run-step name |
|---|---|
| prime | Prime prior versions and migrations |
| generate | Generate and compile MCP server |
| publish | Publish MCP server binary to GitHub release |
| save | Commit back generated artifacts |

Minimal/targeted (4 files); avoids a full regen (which would strip the Dockerfile's SHA-256 digest pin locally).

## When it shows up

The names come from the **pinned** orb, so this takes effect once: this merges → a new gen-orb-mcp release packs the updated `orb/src` → `build_mcp_server`'s pin is bumped to that release.

## Validation

- `circleci orb pack orb/src` → exit 0; packed output carries all four curated names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
