### PR TITLE
fix: enable git2 https+ssh features; MSRV 1.91

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   min_rust_version:
     type: string
-    default: "1.87"
+    default: "1.91"
 
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,6 +1944,8 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
  "url",
 ]
 
@@ -2772,7 +2774,9 @@ checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
 ]
 
@@ -2802,6 +2806,20 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3015,7 +3033,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
  "security-framework",
@@ -3367,6 +3385,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -4471,7 +4495,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
  "security-framework",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 authors = ["Jeremiah Russell <jrussell@jerus.ie>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/jerus-org/gen-orb-mcp"
-rust-version = "1.87"
+rust-version = "1.91"
 keywords = ["mcp", "circleci", "orb", "codegen"]
 categories = ["development-tools", "command-line-utilities"]
 
@@ -52,7 +52,11 @@ octocrate = { version = "2.2.0", default-features = false, features = [
 ] }
 
 # Git operations — staging, committing, pushing for the save subcommand
-git2 = "0.21.0"
+# git2 0.21 changed its default features to `[]` (0.20 defaulted to
+# ["ssh", "https"]). Without `https`, libgit2 is built with no TLS backend and
+# `save`'s git push fails at runtime ("there is no TLS stream available").
+# Enable them explicitly; `ssh` keeps SSH remotes working too.
+git2 = { version = "0.21.0", features = ["ssh", "https"] }
 git2_credentials = "0.16.0"
 
 # Signed commit and GitHub App token push (for save --sign).

--- a/crates/gen-orb-mcp/src/lib.rs
+++ b/crates/gen-orb-mcp/src/lib.rs
@@ -2419,3 +2419,33 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod git2_build_features {
+    //! Guards the linked libgit2 build features. `git2` 0.21 changed its
+    //! default features to `[]` (0.20 defaulted to `["ssh", "https"]`), so a
+    //! bare `git2 = "0.21"` builds libgit2 WITHOUT a TLS backend — the `save`
+    //! command's HTTPS push then fails at runtime with
+    //! `there is no TLS stream available; class=Ssl (16)`. These tests fail
+    //! fast at test time if the features regress again.
+
+    #[test]
+    fn libgit2_has_https_support() {
+        assert!(
+            git2::Version::get().https(),
+            "linked libgit2 has no HTTPS/TLS backend — `save`'s git push will fail \
+             with 'there is no TLS stream available'. Ensure the `git2` dependency \
+             enables the `https` feature (git2 0.21 dropped it from the defaults)."
+        );
+    }
+
+    #[test]
+    fn libgit2_has_ssh_support() {
+        assert!(
+            git2::Version::get().ssh(),
+            "linked libgit2 has no SSH backend — SSH git remotes will fail. Ensure \
+             the `git2` dependency enables the `ssh` feature (git2 0.21 dropped it \
+             from the defaults)."
+        );
+    }
+}

--- a/justfile
+++ b/justfile
@@ -34,6 +34,18 @@ unit-tests:
 audit:
     cargo deny check advisories bans licenses sources
 
+# verify the documented MSRV (rust-version) still builds with the locked deps.
+# CI's "minimum" build uses the earliest rolling toolchain, which is typically
+# newer than the documented MSRV, so it does NOT validate the true MSRV — run
+# this locally on every change (especially when Cargo.lock changes).
+msrv:
+    cargo msrv verify --manifest-path crates/gen-orb-mcp/Cargo.toml
+
+# discover the true minimum supported rust-version (bisects; run when a dep bump
+# breaks `just msrv`, then bump rust-version + CI min_rust_version to match).
+msrv-find:
+    cargo msrv find --manifest-path crates/gen-orb-mcp/Cargo.toml
+
 # run nightly rustfmt for its extra features, but check that it won't upset stable rustfmt
 fmt:
     cargo +nightly fmt --all -- --config-path rustfmt-nightly.toml


### PR DESCRIPTION
Pre-empts the same git2 0.21 TLS regression just fixed in pcu (#982).

## Problem

`main` is already on `git2 = "0.21.0"` (bare). git2 0.21 changed its default features to `[]` (0.20 defaulted to `["ssh", "https"]`), so libgit2 is built **with no TLS backend** — the `save` command's HTTPS push fails at runtime:

```
Git2 says: there is no TLS stream available; class=Ssl (16)
```

(The `Result`-wrapped API changes from git2 0.21 — e.g. `Reference::shorthand()` — were already adapted in lib.rs; the build is clean.)

## Changes

- **Enable `https` + `ssh` features** on the git2 dependency (restores TLS + SSH transport).
- **Regression test** `git2_build_features`: asserts `git2::Version::get().https()` and `.ssh()`. RED on the bare dep (reproduced the exact failure), GREEN with the features — so this can't silently recur.
- **MSRV 1.87 → 1.91**: pre-existing drift surfaced by `cargo msrv verify` (deps now require up to 1.91 via `pmcp 2.9.0`; CI's rolling toolchain never validated the declared MSRV). Bumped `Cargo.toml` + CI `min_rust_version`.
- **`just msrv` / `just msrv-find`** recipes for local MSRV verification.

## Verification

fmt, clippy, full suite (229 tests incl. the 2 new), `cargo msrv verify` (1.91), `cargo audit` (no new advisories — only the two already-accepted, neither stale) all pass.