### PR TITLE
feat: adopt gen-circleci-orb auto-record

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.4.2
 
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.47
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.48
   gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.46
   orb-tools: circleci/orb-tools@12.4.0
 workflows:
@@ -89,6 +89,11 @@ workflows:
           orb_namespace: jerus-org
           orb_dir: orb
           attach_workspace: true
+          # Auto-record ([record] in gen-circleci-orb.toml): `release` supplies
+          # BOT_* signing material, `bot-check` the GITHUB_TOKEN (contents:write).
+          # The binary records only on a PR branch (no-op on main/forks), so the
+          # regenerated orb is committed back to the PR for review.
+          context: [release, bot-check]
           requires: [build-binary]
       - orb-tools/pack:
           name: pack-orb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.4.2
 
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.48
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.49
   gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.46
   orb-tools: circleci/orb-tools@12.4.0
 workflows:
@@ -171,7 +171,12 @@ workflows:
           pub_type: production
           vcs_type: github
           enable_pr_comment: false
-          requires: [orb-release-container, orb-release-pack, orb-release-ensure-registered-jerus-org]
+          requires:
+            [
+              orb-release-container,
+              orb-release-pack,
+              orb-release-ensure-registered-jerus-org,
+            ]
           context: [orb-publishing]
           filters:
             tags:

--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -6,6 +6,22 @@ git_push_subcommands = ["save"]
 # The Rust executor base and build deps (cargo, gnupg, libssl-dev, pkg-config)
 # are provisioned automatically by gen-circleci-orb because [ci].mcp = true.
 
+# Auto-record: after `generate` regenerates the orb, the regenerate-orb CI job
+# GPG-signs a commit of the orb source and pushes it to the PR branch (for
+# review), keeping the published orb in sync with the CLI. The values are the
+# *names* of the env vars holding the signing material and a contents:write
+# GitHub token; the secret values live in the contexts (release -> BOT_*,
+# bot-check -> GITHUB_TOKEN). The binary records only on a PR branch.
+[record]
+enabled = true
+gpg_key_env = "BOT_GPG_KEY"
+gpg_trust_env = "BOT_TRUST"
+user_name_env = "BOT_USER_NAME"
+user_email_env = "BOT_USER_EMAIL"
+signing_key_env = "BOT_SIGN_KEY"
+write_token_env = "GITHUB_TOKEN"
+contexts = ["release", "bot-check"]
+
 [ci]
 build_workflow = "validation"
 release_workflow = "release"


### PR DESCRIPTION
Completes the auto-record rollout: gen-orb-mcp now records its regenerated orb automatically (gen-circleci-orb v0.0.48).

## Changes

- **Bump** `gen-circleci-orb` orb 0.0.47 → **0.0.48** (the release shipping config-driven auto-record).
- **Add `[record]`** to `gen-circleci-orb.toml`: names the env vars for signing material + a contents:write GitHub token, and the contexts that supply them — `release` → `BOT_*`, `bot-check` → `GITHUB_TOKEN`.
- **Attach `context: [release, bot-check]`** to the `regenerate-orb` job.

## Effect

`regenerate-orb` (the `gen-circleci-orb/generate` step) now GPG-signs a commit of the regenerated orb source and pushes it back to the **PR branch** for review — so the published orb stays in sync with the CLI without a maintainer regenerating locally. The binary gates recording to a real PR branch (no-op on main / forked PRs).

## Notes

- CI-config + toml only; no Rust changes.
- Independent of #201 (gen-orb-mcp's own git2 0.21 fix) — the regenerate-orb record push is performed by the gen-circleci-orb orb (pcu 0.6.25, git2 fix included), not gen-orb-mcp's binary.
- The toolkit version here is still 6.3.0; the skip-ci (toolkit 6.4.2) propagation is a separate Renovate bump.