### PR TITLE
feat: adopt gen-circleci-orb 0.0.50 (Model B auto-record)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.4.2
 
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.50
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.51
   gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.46
   orb-tools: circleci/orb-tools@12.4.0
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.4.2
 
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.49
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.50
   gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.46
   orb-tools: circleci/orb-tools@12.4.0
 workflows:
@@ -89,20 +89,43 @@ workflows:
           orb_namespace: jerus-org
           orb_dir: orb
           attach_workspace: true
-          # Auto-record ([record] in gen-circleci-orb.toml): `release` supplies
-          # BOT_* signing material, `bot-check` the GITHUB_TOKEN (contents:write).
-          # The binary records only on a PR branch (no-op on main/forks), so the
-          # regenerated orb is committed back to the PR for review.
-          context: [release, bot-check]
+          # Model B: regenerate but do NOT push (no_record); persist the orb to
+          # the workspace so pack/review validate the regenerated orb, and the
+          # end push-orb job commits + pushes once, after validation. `release`
+          # supplies the BOT_* GPG signing material.
+          no_record: true
+          persist_orb_workspace: true
+          context: [release]
           requires: [build-binary]
       - orb-tools/pack:
           name: pack-orb
+          checkout: false
           source_dir: orb/src
+          pre-steps:
+            - attach_workspace:
+                at: .
           requires: [regenerate-orb]
       - orb-tools/review:
           name: review-orb
+          checkout: false
           source_dir: orb/src
+          pre-steps:
+            - attach_workspace:
+                at: .
           requires: [pack-orb]
+      # End push: regenerate WITH record (signed commit + push), gated on the
+      # orb validations (atomic). add_ssh_keys loads the org write key
+      # (ssh_fingerprint) so the push has write authority; `release` supplies
+      # the GPG signing material.
+      - gen-circleci-orb/generate:
+          name: push-orb
+          binary: gen-orb-mcp
+          orb_namespace: jerus-org
+          orb_dir: orb
+          attach_workspace: true
+          ssh_fingerprint: "SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg"
+          context: [release]
+          requires: [pack-orb, review-orb]
 
   orb-release:
     jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1259,7 +1259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4076,9 +4076,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -4729,7 +4729,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "sha1collisiondetection",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "xxhash-rust",
 ]
 

--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -19,8 +19,11 @@ gpg_trust_env = "BOT_TRUST"
 user_name_env = "BOT_USER_NAME"
 user_email_env = "BOT_USER_EMAIL"
 signing_key_env = "BOT_SIGN_KEY"
-write_token_env = "GITHUB_TOKEN"
-contexts = ["release", "bot-check"]
+# Push uses the org SSH write key (loaded by add_ssh_keys in the push job),
+# not a token — add_ssh_keys resolves the fingerprint at config-compile time
+# and can't read env vars, so this is a value, not an env-var name.
+push_ssh_fingerprint = "SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg"
+contexts = ["release"]
 
 [ci]
 build_workflow = "validation"

--- a/orb/Dockerfile
+++ b/orb/Dockerfile
@@ -1,12 +1,12 @@
-FROM rust:1-slim-trixie@sha256:3b05f7c617a200c41c3506097f0d15fc193a1c93bfd8f141007b47cac8f95d3c AS builder
+FROM rust:1-slim-trixie AS builder
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/* \
     && cargo install gen-orb-mcp
 
-FROM rust:1-slim-trixie@sha256:3b05f7c617a200c41c3506097f0d15fc193a1c93bfd8f141007b47cac8f95d3c
+FROM rust:1-slim-trixie
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates git gnupg libssl-dev pkg-config \
+    && apt-get install -y --no-install-recommends ca-certificates git gnupg libssl-dev openssh-client pkg-config \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -ms /bin/bash circleci
 COPY --from=builder /usr/local/cargo/bin/gen-orb-mcp /usr/local/bin/gen-orb-mcp

--- a/orb/src/commands/build.yml
+++ b/orb/src/commands/build.yml
@@ -9,7 +9,7 @@ parameters:
     default: ''
 steps:
 - run:
-    name: build
+    name: Compile generated MCP server source to a native binary
     command: <<include(scripts/build.sh)>>
     environment:
       INPUT: << parameters.input >>

--- a/orb/src/commands/diff.yml
+++ b/orb/src/commands/diff.yml
@@ -15,7 +15,7 @@ parameters:
     default: ''
 steps:
 - run:
-    name: diff
+    name: Compute conformance rules by diffing two orb versions
     command: <<include(scripts/diff.sh)>>
     environment:
       CURRENT: << parameters.current >>

--- a/orb/src/commands/generate.yml
+++ b/orb/src/commands/generate.yml
@@ -40,6 +40,12 @@ parameters:
     description: Tag prefix used to discover the orb version from git tags  The git repository is derived automatically from --orb-path. Defaults to "v" (matches tags like v6.0.0).
     default: v
 steps:
+- when:
+    condition: << parameters.force >>
+    steps:
+    - run:
+        name: Set FORCE flag
+        command: echo 'export FORCE=true' >> "$BASH_ENV"
 - run:
     name: Generate and compile MCP server
     command: <<include(scripts/generate.sh)>>
@@ -49,7 +55,6 @@ steps:
       FORMAT: << parameters.format >>
       GENERATE_NAME: << parameters.generate_name >>
       CRATE_VERSION: << parameters.crate_version >>
-      FORCE: << parameters.force >>
       MIGRATIONS: << parameters.migrations >>
       PRIOR_VERSIONS: << parameters.prior_versions >>
       TAG_PREFIX: << parameters.tag_prefix >>

--- a/orb/src/commands/migrate.yml
+++ b/orb/src/commands/migrate.yml
@@ -15,11 +15,16 @@ parameters:
     description: Show planned changes without modifying files
     default: false
 steps:
+- when:
+    condition: << parameters.dry_run >>
+    steps:
+    - run:
+        name: Set DRY_RUN flag
+        command: echo 'export DRY_RUN=true' >> "$BASH_ENV"
 - run:
-    name: migrate
+    name: Apply conformance-based migration to a consumer's .circleci/ directory
     command: <<include(scripts/migrate.sh)>>
     environment:
       CI_DIR: << parameters.ci_dir >>
       ORB: << parameters.orb >>
       RULES: << parameters.rules >>
-      DRY_RUN: << parameters.dry_run >>

--- a/orb/src/commands/prime.yml
+++ b/orb/src/commands/prime.yml
@@ -41,6 +41,18 @@ parameters:
     description: Describe actions without writing any files
     default: false
 steps:
+- when:
+    condition: << parameters.ephemeral >>
+    steps:
+    - run:
+        name: Set EPHEMERAL flag
+        command: echo 'export EPHEMERAL=true' >> "$BASH_ENV"
+- when:
+    condition: << parameters.dry_run >>
+    steps:
+    - run:
+        name: Set DRY_RUN flag
+        command: echo 'export DRY_RUN=true' >> "$BASH_ENV"
 - run:
     name: Prime prior versions and migrations
     command: <<include(scripts/prime.sh)>>
@@ -52,6 +64,4 @@ steps:
       SINCE: << parameters.since >>
       PRIOR_VERSIONS_DIR: << parameters.prior_versions_dir >>
       MIGRATIONS_DIR: << parameters.migrations_dir >>
-      EPHEMERAL: << parameters.ephemeral >>
       RENAME_MAP: << parameters.rename_map >>
-      DRY_RUN: << parameters.dry_run >>

--- a/orb/src/commands/publish.yml
+++ b/orb/src/commands/publish.yml
@@ -25,6 +25,12 @@ parameters:
     description: Describe the upload without performing it
     default: false
 steps:
+- when:
+    condition: << parameters.dry_run >>
+    steps:
+    - run:
+        name: Set DRY_RUN flag
+        command: echo 'export DRY_RUN=true' >> "$BASH_ENV"
 - run:
     name: Publish MCP server binary to GitHub release
     command: <<include(scripts/publish.sh)>>
@@ -34,4 +40,3 @@ steps:
       BINARY: << parameters.binary >>
       ASSET_NAME: << parameters.asset_name >>
       TAG: << parameters.tag >>
-      DRY_RUN: << parameters.dry_run >>

--- a/orb/src/commands/save.yml
+++ b/orb/src/commands/save.yml
@@ -27,6 +27,24 @@ parameters:
     description: 'Use GPG-signed commit and GitHub App token push.  Reads: BOT_GPG_KEY (base64 GPG key), BOT_TRUST (ownertrust), BOT_USER_NAME, BOT_USER_EMAIL, BOT_SIGN_KEY (key ID), GITHUB_TOKEN (GitHub App installation token), CIRCLE_PROJECT_USERNAME, CIRCLE_PROJECT_REPONAME, CIRCLE_BRANCH.'
     default: false
 steps:
+- when:
+    condition: << parameters.no_push >>
+    steps:
+    - run:
+        name: Set NO_PUSH flag
+        command: echo 'export NO_PUSH=true' >> "$BASH_ENV"
+- when:
+    condition: << parameters.dry_run >>
+    steps:
+    - run:
+        name: Set DRY_RUN flag
+        command: echo 'export DRY_RUN=true' >> "$BASH_ENV"
+- when:
+    condition: << parameters.sign >>
+    steps:
+    - run:
+        name: Set SIGN flag
+        command: echo 'export SIGN=true' >> "$BASH_ENV"
 - run:
     name: Commit back generated artifacts
     command: <<include(scripts/save.sh)>>
@@ -34,6 +52,3 @@ steps:
       PATHS: << parameters.paths >>
       MESSAGE: << parameters.message >>
       PUSH: << parameters.push >>
-      NO_PUSH: << parameters.no_push >>
-      DRY_RUN: << parameters.dry_run >>
-      SIGN: << parameters.sign >>

--- a/orb/src/commands/validate.yml
+++ b/orb/src/commands/validate.yml
@@ -6,7 +6,7 @@ parameters:
     default: src/@orb.yml
 steps:
 - run:
-    name: validate
+    name: Validate an orb definition without generating
     command: <<include(scripts/validate.sh)>>
     environment:
       ORB_PATH: << parameters.orb_path >>

--- a/orb/src/jobs/build_mcp_server.yml
+++ b/orb/src/jobs/build_mcp_server.yml
@@ -51,21 +51,21 @@ steps:
       TAG_PREFIX: << parameters.tag_prefix >>
       WORKSPACE_BIN_PATH: << parameters.workspace_root >>
 - prime:
+    earliest_version: << parameters.earliest_version >>
     orb_path: << parameters.orb_path >>
     tag_prefix: << parameters.tag_prefix >>
-    earliest_version: << parameters.earliest_version >>
 - generate:
+    force: true
     format: binary
     generate_name: << parameters.binary_name >>
+    migrations: << parameters.migrations_dir >>
     orb_path: << parameters.orb_path >>
     output: /tmp/mcp-server
-    force: true
     prior_versions: << parameters.prior_versions_dir >>
-    migrations: << parameters.migrations_dir >>
     tag_prefix: << parameters.tag_prefix >>
 - publish:
-    publish_name: << parameters.binary_name >>
     input: /tmp/mcp-server
+    publish_name: << parameters.binary_name >>
 - save:
     paths: << parameters.prior_versions_dir >>,<< parameters.migrations_dir >>
     sign: true

--- a/orb/src/scripts/add-workspace-to-path.sh
+++ b/orb/src/scripts/add-workspace-to-path.sh
@@ -1,1 +1,1 @@
-export PATH="${WORKSPACE_ROOT}:${PATH}"
+echo "export PATH=\"${WORKSPACE_ROOT}:\$PATH\"" >> "$BASH_ENV"


### PR DESCRIPTION
Adopts **gen-circleci-orb 0.0.50** and the redesigned (Model B) auto-record. This is the propagation step after the redesign landed in gen-circleci-orb (3a/3b/3c) and 0.0.50 was released.

## Changes

- **Orb pin** `jerus-org/gen-circleci-orb` 0.0.49 → **0.0.50**.
- **Model B workflow** (mirrors what 0.0.50's `init`/ci_patcher now generates):
  - `regenerate-orb`: `no_record: true` + `persist_orb_workspace: true` — regenerates and persists the orb to the workspace instead of the binary pushing.
  - `pack-orb`/`review-orb`: `checkout: false` + `attach_workspace` — validate the *regenerated* orb (not the committed copy).
  - **new `push-orb`**: regenerates **with** record (signed commit + push), gated on `[pack-orb, review-orb]` (atomic), loading the org write key via `ssh_fingerprint`.
- **`[record]`**: drop `write_token_env` (no PAT push); add `push_ssh_fingerprint` (the org SSH write key — a *value*, not an env-var name, since `add_ssh_keys` resolves fingerprints at config-compile time and can't read env vars); `contexts` `release, bot-check` → `release`.

## First real end-to-end push

`orb/` is intentionally **not** regenerated locally — this PR's own CI exercises the redesigned push for the first time: `regenerate-orb` (0.0.50) → persist → pack/review validate → `push-orb` commits + pushes the regenerated orb back to this branch (a `chore: regenerate orb` commit, carrying the ci-skip marker so it doesn't re-trigger).

## ⚠️ Needs confirmation

`push-orb` loads the org write key `SHA256:Okxs…` via `add_ssh_keys`. This is confirmed registered for **gen-circleci-orb**'s CircleCI project; **please confirm it's also registered for gen-orb-mcp's project**. If not, `push-orb`'s `add_ssh_keys` fails on this PR (recoverable — register the key or correct the fingerprint).

## Also folds in the quinn-proto security fix (was #210)

`RUSTSEC-2026-0185` (quinn-proto 0.11.14, high) fails `cargo audit` on gen-orb-mcp too. It's folded into this PR (`0.11.14 → 0.11.15`) rather than landing standalone, because the two are coupled: a standalone quinn-proto fix on main **can't go green** — main's *old* auto-record fails the regenerate-orb push, and this PR is what fixes that (Model B: regenerate-orb runs `no_record`, so there's no broken push; the new `push-orb` does the real push). So this PR resolves both the audit failure and the auto-record failure together. (#210 left open for you to close in favour of this.)