### PR TITLE
fix: lift RUSTSEC-2026-0173 + prune stale ignore

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,18 +4,4 @@ ignore = [
     # Pulled in transitively by pcu → sigstore → openidconnect → rsa.
     # Cannot be resolved without upstream pcu/sigstore/rsa patches.
     "RUSTSEC-2023-0071",
-    # RUSTSEC-2024-0370: proc-macro-error is unmaintained (warning only).
-    # Pulled in transitively by pcu → sigstore → json-syntax → locspan-derive.
-    # Cannot be resolved without upstream pcu/sigstore patches.
-    "RUSTSEC-2024-0370",
-    # RUSTSEC-2026-0173: proc-macro-error2 is unmaintained (advisory 2026-06-07).
-    # The proc-macro-error2 repo is ARCHIVED (read-only) so it will never be patched.
-    # Reaches this repo transitively, via pcu:
-    #   pcu → sigstore → oci-client → oci-spec → getset → proc-macro-error2
-    #     (getset is the blocker: no release since 2025-06; getset#132 tracks it)
-    #   pcu → gen-bsky → aquamarine → proc-macro-error2
-    #     (aquamarine is docs-only; being removed from gen-bsky in-house)
-    # Upstream tracking: jbaublitz/getset#132, youki-dev/oci-spec-rs#340.
-    # TEMPORARY — review weekly; remove once a fixed getset/oci-spec ships.
-    "RUSTSEC-2026-0173",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,11 +1918,10 @@ dependencies = [
 
 [[package]]
 name = "getset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3920,28 +3919,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- Bump `getset` 0.1.6 → **0.1.7**, which drops `proc-macro-error2` (the
  archived/unmaintained crate behind **RUSTSEC-2026-0173**). It was the sole
  remaining path here; `oci-spec` requires `getset ^0.1.3` which permits 0.1.7,
  so a plain `cargo update -p getset --precise 0.1.7` clears it with no oci-spec
  change. The `gen-bsky → aquamarine` path was already removed upstream.
- Remove the `RUSTSEC-2026-0173` ignore from `.cargo/audit.toml`.
- **Also prune the stale `RUSTSEC-2024-0370` ignore.** `proc-macro-error`,
  `json-syntax` and `locspan-derive` are no longer in the lock (removed by a
  prior dependency update), so that ignore no longer matches anything. Per the
  standing stale-ignore policy, removed in the same PR.

`RUSTSEC-2023-0071` (rsa / Marvin attack) stays — still upstream-blocked.

## Verification

- Naked audit (no config, from `/tmp`): only `RUSTSEC-2023-0071` — no
  `proc-macro-error2`, no `proc-macro-error`.
- Configured audit: exit 0.
- `cargo fmt --all --check`, `clippy --all-targets --all-features -D warnings`,
  229 tests, `cargo msrv verify` @ 1.91.0 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
