### PR TITLE
ci: Stage 1 tidy — toolkit pins, verify_tools, anyhow fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.5.0
 
-  gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.47
+  gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.46
   orb-tools: circleci/orb-tools@12.4.0
   # >>> gen-circleci-orb (managed — edits overwritten by 'gen-circleci-orb update')
   gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.53
@@ -226,7 +226,7 @@ workflows:
             branches:
               ignore: /.*/
 
-      - gen-orb-mcp/build_mcp_server:
+      - gen-circleci-orb/build_mcp_server:
           name: build-mcp-server
           binary_name: gen-orb-mcp
           tag_prefix: gen-orb-mcp-v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,9 @@ parameters:
     default: "1.91"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.4.2
+  toolkit: jerus-org/circleci-toolkit@6.5.0
 
-  gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.46
+  gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.47
   orb-tools: circleci/orb-tools@12.4.0
   # >>> gen-circleci-orb (managed — edits overwritten by 'gen-circleci-orb update')
   gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.53
@@ -226,7 +226,7 @@ workflows:
             branches:
               ignore: /.*/
 
-      - gen-circleci-orb/build_mcp_server:
+      - gen-orb-mcp/build_mcp_server:
           name: build-mcp-server
           binary_name: gen-orb-mcp
           tag_prefix: gen-orb-mcp-v

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -11,7 +11,7 @@ parameters:
     description: "Override workspace v* version (empty = nextsv auto-detect)"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.4.2
+  toolkit: jerus-org/circleci-toolkit@6.5.0
 
 jobs:
   tools:

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -13,27 +13,12 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.5.0
 
-jobs:
-  tools:
-    executor: toolkit/rust_env_rolling
-    steps:
-      - run:
-          name: Verify tools
-          command: |
-            set -ex
-            nextsv --version
-            pcu --version
-            cargo release --version
-            rsign --version
-
 workflows:
   release:
     jobs:
-      - tools
-
       - toolkit/calculate_versions:
           name: calculate-versions
-          requires: [tools]
+          verify_tools: true
           crates: "gen-orb-mcp:gen-orb-mcp-v"
           crate_version_overrides: "gen-orb-mcp:<< pipeline.parameters.gen_orb_mcp_version >>"
           workspace_version_override: << pipeline.parameters.workspace_version >>

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -7,7 +7,7 @@ parameters:
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.4.2
+  toolkit: jerus-org/circleci-toolkit@6.5.0
 
 workflows:
   update_prlog:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"


### PR DESCRIPTION
## Stage 1 — CI orb-source tidy-up + early dogfood

Part of the orb-availability / v0.1.0 release plan.

### Changes
- **Dogfood**: repoint `build-mcp-server` from `gen-circleci-orb/build_mcp_server` → **`gen-orb-mcp/build_mcp_server`**. Building an MCP server is gen-orb-mcp's own concern, so it should run from gen-orb-mcp's orb. The job is tag-gated (`gen-orb-mcp-v*`): it **compiles at config-setup on this PR** (validating the orb job + params resolve) and **runs at the next orb-release tag**.
- **Refresh stale orb pins**:
  - `toolkit` 6.4.2 → **6.5.0** (config / release / update_prlog)
  - `gen-orb-mcp` self 0.1.46 → **0.1.47** (latest *published orb* version — note the orb sequence lags the crate version; 0.1.47 carries `build_mcp_server`)

### Deferred (intentionally)
- **gen-circleci-orb shedding `build_mcp_server`** + reconciling its own MCP-server build → **Stage 3**. The two `build_mcp_server` jobs have diverged interfaces (gen-orb-mcp: native `prime→generate→publish→save`; gen-circleci-orb: a `gen_orb_mcp_tag` wrapper), so the cross-repo cede needs care + CI validation.
- **inline `tools:` → `toolkit/calculate_versions verify_tools`**: `verify_tools` is on toolkit `main` but **not in released 6.5.0** — blocked until a toolkit release ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update:** verify_tools swap is now **included** (not deferred). The published `jerus-org/circleci-toolkit@6.5.0` does carry `verify_tools` on `calculate_versions` — my earlier "blocked" read was a stale **local git tag** vs the packed orb. `release.yml` now drops the inline `tools:` job + `requires:[tools]` and sets `verify_tools: true` (default tool list matches this repo).

Only remaining deferral: gen-circleci-orb shedding `build_mcp_server` → Stage 3.

---

**Correction (dogfood repoint reverted):** the `build-mcp-server` invocation is **managed by gen-circleci-orb** — its `update --check` gate regenerates it as `gen-circleci-orb/build_mcp_server` and fails on a hand-repoint to `gen-orb-mcp/build_mcp_server` ("CI wiring is out of date"). The dogfood relocation must come from gen-circleci-orb **ceding** the job in its generation (Stage 3), not a manual edit, so it's reverted here.

Also added: **anyhow 1.0.102 → 1.0.103** (RUSTSEC-2026-0190) to clear the security job.

**Final Stage 1 scope:** toolkit pins 6.4.2→6.5.0 (×3) · inline `tools:` → `verify_tools` · anyhow security bump. The dogfood + gen-circleci-orb cede move wholesale to Stage 3.