### PR TITLE
ci: dogfood gen-orb-mcp/build_mcp_server (adopt cede)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ orbs:
   gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.46
   orb-tools: circleci/orb-tools@12.4.0
   # >>> gen-circleci-orb (managed — edits overwritten by 'gen-circleci-orb update')
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.53
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.54
   # <<< gen-circleci-orb
 workflows:
   validation:
@@ -226,7 +226,7 @@ workflows:
             branches:
               ignore: /.*/
 
-      - gen-circleci-orb/build_mcp_server:
+      - gen-orb-mcp/build_mcp_server:
           name: build-mcp-server
           binary_name: gen-orb-mcp
           tag_prefix: gen-orb-mcp-v


### PR DESCRIPTION
Adopts the build_mcp_server cede (gen-circleci-orb **0.0.54**, Mechanism A) via `gen-circleci-orb update` — the canonical re-sync, so the `update` gate is satisfied (the Stage-1 hand-edit failed exactly this gate).

```diff
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.53
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.54
...
-      - gen-circleci-orb/build_mcp_server:
+      - gen-orb-mcp/build_mcp_server:
```

build-mcp-server now runs from **gen-orb-mcp own orb** (`gen-orb-mcp/build_mcp_server@0.1.46`). The hand-authored gen-orb-mcp pin is preserved (the generator skips the orbs entry when already declared).

Tag-gated (`gen-orb-mcp-v*`): compiles on this PR (job + orb resolve; validated — the only `circleci config validate` error is the private toolkit orb false-negative), runs end-to-end on the next release tag = the runtime dogfood of gen-orb-mcp own native MCP build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)