### PR TITLE
fix: repair build-mcp-server signed save-back

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.5.0
 
-  gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.46
+  gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.48
   orb-tools: circleci/orb-tools@12.4.0
   # >>> gen-circleci-orb (managed — edits overwritten by 'gen-circleci-orb update')
   gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.54

--- a/gen-orb-mcp.toml
+++ b/gen-orb-mcp.toml
@@ -1,0 +1,14 @@
+# gen-orb-mcp configuration for THIS repository.
+#
+# Maps gen-orb-mcp's generic signing env-var NAMES (the #185 defaults —
+# GPG_KEY / GPG_TRUST / GIT_USER_NAME / GIT_USER_EMAIL / GPG_SIGN_KEY) to the
+# env-var names this project actually provides via its CircleCI release
+# context. Only the NAMES live here (safe to commit); the secret values stay
+# in the context. Auto-discovered in the working directory by `save --sign`
+# (e.g. the build_mcp_server job's commit-back).
+[sign]
+gpg_key_env    = "BOT_GPG_KEY"
+trust_env      = "BOT_TRUST"
+user_name_env  = "BOT_USER_NAME"
+user_email_env = "BOT_USER_EMAIL"
+sign_key_env   = "BOT_SIGN_KEY"


### PR DESCRIPTION
The dogfood release surfaced `build-mcp-server`s `save` step failing: `config value 'user.name' was not found`. Root cause is a **two-part version trap**:

| | pinned **0.1.46** (failing) | fresh **0.1.48** |
|---|---|---|
| env-var names | `BOT_*` (set) | **#185 generic** (`GIT_USER_NAME`… unset) |
| pcu | **0.6.22** — `with_identity` API present but commit path doesnt honour it → git-config read → fail | **0.6.27** — uses `explicit_signature` (no git config) |

The job runs the pinned orbs executor image (`tag` defaults to `0.1.46`), so it ran the *old* binary. 0.1.46 fails on the pcu identity wiring; 0.1.48 alone would fail on the unset #185 name.

## Fix (both parts)
1. **Bump the gen-orb-mcp orb pin 0.1.46 → 0.1.48** — pcu 0.6.27 honours the passed identity.
2. **Add `gen-orb-mcp.toml`** mapping the generic signing env-var *names* → this projects `BOT_*` context secrets (the #185 config deployment). Names only; values stay in the context; auto-discovered where `save` runs.

Tag-gated, so it validates end-to-end on the next release tag.

**Follow-up:** bump gen-circleci-orbs `gen_orb_mcp_orb_version` default 0.1.47 → 0.1.48 so other consumers get the fixed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)