### PR TITLE
fix: clang+cmake for the MCP build image on trixie

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ orbs:
   gen-orb-mcp: jerus-org/gen-orb-mcp@0.1.48
   orb-tools: circleci/orb-tools@12.4.0
   # >>> gen-circleci-orb (managed — edits overwritten by 'gen-circleci-orb update')
-  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.54
+  gen-circleci-orb: jerus-org/gen-circleci-orb@0.0.57
   # <<< gen-circleci-orb
 workflows:
   validation:
@@ -101,6 +101,7 @@ workflows:
           orb_namespace: jerus-org
           orb_dir: orb
           attach_workspace: true
+          check_ci_wiring: false
           ssh_fingerprint: "SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg"
           persist_orb_workspace: true
           context: [release]
@@ -154,6 +155,7 @@ workflows:
           orb_dir: orb
           attach_workspace: true
           check: true
+          check_ci_wiring: false
           requires: [orb-release-binary]
           filters:
             tags:

--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -3,6 +3,10 @@ binary = "gen-orb-mcp"
 namespaces = ["jerus-org"]
 orb_dir = "orb"
 git_push_subcommands = ["save"]
+# Native build deps for the runtime image, where build_mcp_server COMPILES the
+# generated MCP server crate. Its dep tree (rmcp/reqwest → openssl-sys, aws-lc-sys)
+# uses bindgen/cmake, which need libclang + cmake on trixie's newer OpenSSL.
+apt_packages = ["build-essential", "clang", "cmake"]
 # The Rust executor base and build deps (cargo, gnupg, libssl-dev, pkg-config)
 # are provisioned automatically by gen-circleci-orb because [ci].mcp = true.
 

--- a/orb/Dockerfile
+++ b/orb/Dockerfile
@@ -1,12 +1,12 @@
 FROM rust:1-slim-trixie AS builder
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates libssl-dev pkg-config \
+    && apt-get install -y --no-install-recommends build-essential ca-certificates clang cmake libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/* \
-    && cargo install gen-orb-mcp
+    && cargo install gen-orb-mcp --locked
 
 FROM rust:1-slim-trixie
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates git gnupg libssl-dev openssh-client pkg-config \
+    && apt-get install -y --no-install-recommends build-essential ca-certificates clang cmake git gnupg libssl-dev openssh-client pkg-config \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -ms /bin/bash circleci
 COPY --from=builder /usr/local/cargo/bin/gen-orb-mcp /usr/local/bin/gen-orb-mcp


### PR DESCRIPTION
`build_mcp_server` fails at "Generate and compile MCP server" — the generated MCP crate won't compile in the gen-orb-mcp image (libclang not found). Same root cause as the gen-circleci-orb container (jerus-org/gen-circleci-orb#168) and ci-container (jerus-org/ci-container#527): on trixie's **OpenSSL 3.5.6**, `openssl-sys` falls to **bindgen** (needs libclang) and `aws-lc-sys` needs **cmake**, and the slim image ships neither.

gen-orb-mcp's own dep tree (`Cargo.lock`) pulls `openssl-sys`, `aws-lc-sys`, `aws-lc-fips-sys`, `bindgen` — so **both** Docker stages need the deps:

| stage | why | how |
|---|---|---|
| **runtime** (compiles the MCP crate in `build_mcp_server`) | rmcp/reqwest → openssl-sys/aws-lc | `[orb] apt_packages = build-essential, clang, cmake` |
| **builder** (`cargo install gen-orb-mcp`) | its own deps → openssl-sys/aws-lc | pin bump 0.0.54 → **0.0.57** picks up gen-circleci-orb#168's builder deps + `--locked` |

## Changes
- `gen-circleci-orb.toml`: add `[orb] apt_packages`
- pin `gen-circleci-orb@0.0.54 → 0.0.57`, regenerate → `orb/Dockerfile` builder+runtime get clang/cmake (builder also `--locked`)
- config.yml also gains `check_ci_wiring: false` on regenerate-orb + verify-orb (from 0.0.57 / gen-circleci-orb#167's default-flip)

`orb/src` is intentionally **not** committed here — this repo's own CI re-renders it with its fresh binary (my local `gen-orb-mcp` was 0.1.45, which would have stripped the #185 `--*-env` params from `save`).

## Impact
Unblocks `build_mcp_server` for **both** gen-orb-mcp and gen-circleci-orb (0.0.57's release hit the same wall — its `build-mcp-server` runs in this image).

CI-config only; validated with yamllint + orb structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)