### PR TITLE
fix: pin orb image digests in config

### DIFF
--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -9,6 +9,17 @@ git_push_subcommands = ["save"]
 apt_packages = ["build-essential", "clang", "cmake"]
 # The Rust executor base and build deps (cargo, gnupg, libssl-dev, pkg-config)
 # are provisioned automatically by gen-circleci-orb because [ci].mcp = true.
+#
+# Pinned Rust images for the generated Dockerfile. mcp = true defaults both the
+# builder and runtime stages to an *unpinned* rust:1-slim-trixie, so without
+# pinning here the @sha256 digest is stripped on every regeneration (the orb
+# Dockerfile is regenerated from this config, not from Renovate's in-Dockerfile
+# edit). Pinned here so the digest survives regeneration; Renovate keeps both up
+# to date via customManagers (renovate.json), which also disables Renovate's
+# dockerfile manager on the generated orb/Dockerfile so this toml is the single
+# source of truth. Same image + digest for both stages (both rust:1-slim-trixie).
+builder_image = "rust:1-slim-trixie@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523"
+base_image = "rust:1-slim-trixie@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523"
 
 # Auto-record: after `generate` regenerates the orb, the regenerate-orb CI job
 # GPG-signs a commit of the orb source and pushes it to the PR branch (for

--- a/orb/Dockerfile
+++ b/orb/Dockerfile
@@ -1,10 +1,10 @@
-FROM rust:1-slim-trixie AS builder
+FROM rust:1-slim-trixie@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523 AS builder
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential ca-certificates clang cmake libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/* \
     && cargo install gen-orb-mcp --locked
 
-FROM rust:1-slim-trixie
+FROM rust:1-slim-trixie@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential ca-certificates clang cmake git gnupg libssl-dev openssh-client pkg-config \
     && rm -rf /var/lib/apt/lists/* \

--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,41 @@
   ],
   "extends": [
     "github>jerusdp/renovate-config:default.json"
+  ],
+  "packageRules": [
+    {
+      "description": "orb/Dockerfile is a generated artifact. Image digests are pinned in gen-circleci-orb.toml ([orb].base_image / builder_image) and re-emitted on every regeneration, which strips any digest Renovate writes directly into the Dockerfile. Disable the dockerfile manager here so the toml stays the single source of truth.",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchFileNames": [
+        "orb/Dockerfile"
+      ],
+      "enabled": false
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the pinned Rust builder image digest in gen-circleci-orb.toml ([orb].builder_image)",
+      "managerFilePatterns": [
+        "/^gen-circleci-orb\\.toml$/"
+      ],
+      "matchStrings": [
+        "builder_image\\s*=\\s*\"(?<depName>[^:\"]+):(?<currentValue>[^@\"]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
+      ],
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the pinned Rust runtime base image digest in gen-circleci-orb.toml ([orb].base_image)",
+      "managerFilePatterns": [
+        "/^gen-circleci-orb\\.toml$/"
+      ],
+      "matchStrings": [
+        "base_image\\s*=\\s*\"(?<depName>[^:\"]+):(?<currentValue>[^@\"]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
+      ],
+      "datasourceTemplate": "docker"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Preventive fix — applies the same pattern as gen-circleci-orb#174 to gen-orb-mcp's own generated orb, **before** the churn loop starts here.

### The latent trap

- `mcp = true` defaults **both** the builder and runtime `FROM` stages of the generated `orb/Dockerfile` to an **unpinned** `rust:1-slim-trixie`.
- The shared Renovate config (`jerusdp/renovate-config`) has `pinDigests: true`, so Renovate will pin the digests directly into the generated `orb/Dockerfile`.
- `regenerate-orb` rewrites `orb/Dockerfile` from `gen-circleci-orb.toml` (not from Renovate's edit), so the next regeneration **strips** the digest → Renovate re-pins → loop.

gen-orb-mcp isn't churning *yet* only because its `FROM` lines are still bare (Renovate hasn't pinned them). This fixes it before that happens.

## Fix

1. **`gen-circleci-orb.toml`** — pin `[orb].base_image` + `[orb].builder_image` (same image + digest, `rust:1-slim-trixie@sha256:31ee7fc…`, resolved fresh from the registry). Re-emitted verbatim on every regeneration.
2. **`renovate.json`** — two `customManagers` to keep those toml lines up to date.
3. **`renovate.json`** — packageRule disabling Renovate's `dockerfile` manager on the generated `orb/Dockerfile` (toml is the single source of truth).
4. **`orb/Dockerfile`** — regenerated with the pinned gen-circleci-orb `0.0.57` (the version this repo pins), so the diff is **only** the two `FROM` lines.

## Verification

- `generate --check` clean (committed orb matches config; no unrelated drift)
- Both `FROM` lines carry the digest
- `cargo fmt --all --check` + clippy (`--all --tests --all-features -D warnings`) + `cargo audit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)