### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Why

`RUSTSEC-2026-0204` (published 2026-07-06) landed in the RustSec advisory DB while branches were in flight, so `cargo audit -D warnings` began failing on **main** and on the in-flight `renovate/gen-circleci-orb-0.x` orb-pin branch (validation → *security with sonarcloud*).

- **Crate:** `crossbeam-epoch` 0.9.18
- **Issue:** invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid
- **Pulled transitively** via `rayon` (criterion/trycmd dev-deps, tame-index→kdeets→pcu) and `moka`
- **Fix:** upgrade to ≥0.9.20

## What

`cargo update -p crossbeam-epoch` → **0.9.18 → 0.9.20**. Lockfile-only (2 lines).

Verified: `cargo audit` clean, `cargo clippy --all --tests --all-features -D warnings` clean, `cargo fmt --all --check` clean, full test suite green.

Once merged, the Renovate orb-pin PR rebases and its security job goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
