### PR TITLE
fix: rust_image for build binary jobs (libclang)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,13 +95,14 @@ workflows:
       - gen-circleci-orb/build_rust_binary:
           name: build-binary
           package: gen-orb-mcp
+          rust_image: jerusdp/ci-rust:rolling-6mo@sha256:2256d29b9b92041dd29b9575aeac5c45abe539696c9db670c685b47f67df1f01
       - gen-circleci-orb/generate:
           name: regenerate-orb
           binary: gen-orb-mcp
           orb_namespace: jerus-org
           orb_dir: orb
           attach_workspace: true
-          check_ci_wiring: false
+          check_ci_wiring: true
           ssh_fingerprint: "SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg"
           persist_orb_workspace: true
           context: [release]
@@ -142,6 +143,7 @@ workflows:
       - gen-circleci-orb/build_rust_binary:
           name: orb-release-binary
           package: gen-orb-mcp
+          rust_image: jerusdp/ci-rust:rolling-6mo@sha256:2256d29b9b92041dd29b9575aeac5c45abe539696c9db670c685b47f67df1f01
           filters:
             tags:
               only: /^gen-orb-mcp-v.*/

--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -56,6 +56,15 @@ mcp_context = [
     "pcu-app",
 ]
 mcp_earliest_version = "0.1.11"
+# Image the build_rust_binary CI jobs (build-binary, orb-release-binary) compile
+# in. This configures the CI pipeline, not the orb's own container ([orb].base_image
+# / builder_image do that). Overrides the job default (rust:latest), which has NO
+# libclang — bindgen fails there (openssl-sys via sequoia-openpgp's OpenSSL backend
+# once it pulls the ossl crate, reached transitively through pcu). ci-rust:rolling-6mo
+# is the toolkit's clang-equipped compile image. Digest-pinned so it survives
+# regeneration and CircleCI can't serve a stale moving tag from cache; Renovate
+# updates the digest via a customManager (renovate.json).
+rust_image = "jerusdp/ci-rust:rolling-6mo@sha256:2256d29b9b92041dd29b9575aeac5c45abe539696c9db670c685b47f67df1f01"
 
 [subcommand.help]
 generate_job = false

--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,17 @@
         "base_image\\s*=\\s*\"(?<depName>[^:\"]+):(?<currentValue>[^@\"]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the pinned build image digest in gen-circleci-orb.toml ([ci].rust_image)",
+      "managerFilePatterns": [
+        "/^gen-circleci-orb\\.toml$/"
+      ],
+      "matchStrings": [
+        "rust_image\\s*=\\s*\"(?<depName>[^:\"]+):(?<currentValue>[^@\"]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
+      ],
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
Mirrors gen-circleci-orb #184 for gen-orb-mcp — its lock-file-maintenance PR fails `build-binary` with the same clang deficit.

## Why
`gen-circleci-orb/build_rust_binary` defaults `rust_image` to **`rust:latest`** (no libclang). Once the lockfile pulls **sequoia-openpgp 2.4.0** (via pcu), its OpenSSL backend drags in `openssl-sys` with the `bindgen` feature, and bindgen panics: `Unable to find libclang`. Every other job passes — they run in the clang-equipped `ci-rust:rolling-6mo`.

## Change
- Set **`[ci].rust_image`** in `gen-circleci-orb.toml` to the digest-pinned `ci-rust:rolling-6mo` (toolkit compile image, has clang + libclang), Renovate-tracked via a `customManager`.
- Regenerated `config.yml` with the pinned **gen-circleci-orb 0.0.61** binary (which supports the knob), adding `rust_image:` to `build-binary` + `orb-release-binary`.
- The regen also flips `check_ci_wiring: false → true` on validation `regenerate-orb` — a latent drift fix: Renovate bumped the gen-circleci-orb pin to 0.0.61 without regenerating the managed blocks, so the committed config was stale from a pre-#173 version.

Verified: `update --check` / `generate --check` clean, clippy clean, fmt clean, audit clean, config validates (only the private toolkit orb is unresolvable locally).

Once merged, the lock-file-maintenance PR rebases onto this and `build-binary` compiles in the clang image → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
