### PR TITLE
fix(deps): update spin to 0.9.9 (drop yanked 0.9.8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5268,9 +5268,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"


### PR DESCRIPTION
## Problem

`spin 0.9.8` has been **yanked** from crates.io. It is a transitive dependency (via `lazy_static`'s `once` feature, pulled by `pcu`/`tracing-subscriber`).

The toolkit `security` job runs `cargo audit -D warnings`, and `-D warnings` promotes the "yanked" warning to a **fatal error**. `$IGNORE_ADVISORIES` only suppresses RUSTSEC advisory *IDs*, not yanks — so every pipeline on this repo now fails on the **unchanged** `Cargo.lock` (seen on renovate/toolkit-6.x #1407).

## Fix

`cargo update -p spin` → `0.9.8 → 0.9.9` (non-yanked). Single-package lockfile change; other dependencies untouched.

Verified locally: `cargo audit -D warnings --ignore RUSTSEC-2023-0071` exits 0.

This is the "yanked between weekly lockfile sweeps" gap — the regular Renovate lockFileMaintenance job would fix it next week, but the security gate is red now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)