### PR TITLE
chore: inherit renovate pin managers from shared config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,52 +5,5 @@
   ],
   "extends": [
     "github>jerusdp/renovate-config:default.json"
-  ],
-  "packageRules": [
-    {
-      "description": "orb/Dockerfile is a generated artifact. Image digests are pinned in gen-circleci-orb.toml ([orb].base_image / builder_image) and re-emitted on every regeneration, which strips any digest Renovate writes directly into the Dockerfile. Disable the dockerfile manager here so the toml stays the single source of truth.",
-      "matchManagers": [
-        "dockerfile"
-      ],
-      "matchFileNames": [
-        "orb/Dockerfile"
-      ],
-      "enabled": false
-    }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Track the pinned Rust builder image digest in gen-circleci-orb.toml ([orb].builder_image)",
-      "managerFilePatterns": [
-        "/^gen-circleci-orb\\.toml$/"
-      ],
-      "matchStrings": [
-        "builder_image\\s*=\\s*\"(?<depName>[^:\"]+):(?<currentValue>[^@\"]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
-      ],
-      "datasourceTemplate": "docker"
-    },
-    {
-      "customType": "regex",
-      "description": "Track the pinned Rust runtime base image digest in gen-circleci-orb.toml ([orb].base_image)",
-      "managerFilePatterns": [
-        "/^gen-circleci-orb\\.toml$/"
-      ],
-      "matchStrings": [
-        "base_image\\s*=\\s*\"(?<depName>[^:\"]+):(?<currentValue>[^@\"]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
-      ],
-      "datasourceTemplate": "docker"
-    },
-    {
-      "customType": "regex",
-      "description": "Track the pinned build image digest in gen-circleci-orb.toml ([ci].rust_image)",
-      "managerFilePatterns": [
-        "/^gen-circleci-orb\\.toml$/"
-      ],
-      "matchStrings": [
-        "rust_image\\s*=\\s*\"(?<depName>[^:\"]+):(?<currentValue>[^@\"]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
-      ],
-      "datasourceTemplate": "docker"
-    }
   ]
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Merge **after** digital-prstv/renovate-config#77, which adds the managers this PR removes. Merging first leaves the pins untracked until #77 lands.

## Why

This is the root cause of the `regenerate-orb` failure on #244 (pipeline #1433). Renovate bumped `[ci].rust_image` in `gen-circleci-orb.toml` to `sha256:0920…`, but `update` also copies that digest into two `rust_image:` lines in `.circleci/config.yml`, which nothing was tracking. They stayed at `sha256:2256…`, and `update --check` failed on drift the bot itself created.

The check is right to fail. Unlike `orb/Dockerfile`, which is regenerated from the toml on every run, CircleCI reads `.circleci/config.yml` from the commit, so the digest is committed and must be updated in place. A rebuilt base image — security fixes included — should flow through without a gen-circleci-orb release; the pin lives in this repo.

## What

The shared config now carries the three `gen-circleci-orb.toml` managers and the `orb/Dockerfile` rule that were hand-copied here, plus a new manager for the digest in `.circleci/*.yml`. Both resolve to `jerusdp/ci-rust`, so the existing `pinned containers` group moves the toml and the config in one PR.

This repo's `renovate.json` reduces to schedule + extends; everything else is inherited.

## After merge

Renovate must regenerate #244 so the bump applies to both files. `rebaseWhen` is `never` in the shared config, so this needs the rebase checkbox on that PR (or the Dependency Dashboard). No manual resync commit required.
