### PR TITLE
fix: run set_https_remote after fetch, not before

### DIFF
--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -169,14 +169,8 @@ NAME = "<< parameters.binary_name >>"
 TAG_PREFIX = "<< parameters.tag_prefix >>"
 WORKSPACE_BIN_PATH = "<< parameters.workspace_root >>"
 
-# set_https_remote MUST run AFTER the fetch above, not before. CircleCI checkout
-# injects an insteadOf rule (HTTPS->SSH) that authenticates `git fetch` via the
-# deploy key on PRIVATE repos; set_https_remote removes that rule and switches
-# origin to literal HTTPS. Running it first left the fetch with no credentials on
-# private repos ("could not read Username for https://github.com"). Fetching
-# first (SSH auth intact) then switching to HTTPS keeps private-repo fetch working
-# while still giving pcu the HTTPS App-token remote for the commit-back in save.
-# Public repos are unaffected either way (anonymous HTTPS fetch also works).
+# set_https_remote must run AFTER the fetch above, not before, or private-repo
+# checkout breaks. See jerus-org/gen-orb-mcp#266.
 [[job_group.step]]
 command = "set_https_remote"
 

--- a/gen-circleci-orb.toml
+++ b/gen-circleci-orb.toml
@@ -149,9 +149,6 @@ builtin = "checkout"
 builtin = "attach_workspace"
 
 [[job_group.step]]
-command = "set_https_remote"
-
-[[job_group.step]]
 run = "Set up git and environment"
 script = '''
 # Use the freshly-built binary if it was attached from the workspace,
@@ -171,6 +168,17 @@ git checkout -B main origin/main
 NAME = "<< parameters.binary_name >>"
 TAG_PREFIX = "<< parameters.tag_prefix >>"
 WORKSPACE_BIN_PATH = "<< parameters.workspace_root >>"
+
+# set_https_remote MUST run AFTER the fetch above, not before. CircleCI checkout
+# injects an insteadOf rule (HTTPS->SSH) that authenticates `git fetch` via the
+# deploy key on PRIVATE repos; set_https_remote removes that rule and switches
+# origin to literal HTTPS. Running it first left the fetch with no credentials on
+# private repos ("could not read Username for https://github.com"). Fetching
+# first (SSH auth intact) then switching to HTTPS keeps private-repo fetch working
+# while still giving pcu the HTTPS App-token remote for the commit-back in save.
+# Public repos are unaffected either way (anonymous HTTPS fetch also works).
+[[job_group.step]]
+command = "set_https_remote"
 
 [[job_group.step]]
 command = "prime"

--- a/orb/src/jobs/build_mcp_server.yml
+++ b/orb/src/jobs/build_mcp_server.yml
@@ -42,7 +42,6 @@ steps:
         command: <<include(scripts/add-workspace-to-path.sh)>>
         environment:
           WORKSPACE_ROOT: << parameters.workspace_root >>
-- set_https_remote
 - run:
     name: Set up git and environment
     command: <<include(scripts/build_mcp_server_set_up_git_and_environment.sh)>>
@@ -50,6 +49,7 @@ steps:
       NAME: << parameters.binary_name >>
       TAG_PREFIX: << parameters.tag_prefix >>
       WORKSPACE_BIN_PATH: << parameters.workspace_root >>
+- set_https_remote
 - prime:
     earliest_version: << parameters.earliest_version >>
     orb_path: << parameters.orb_path >>


### PR DESCRIPTION
Closes #266

## Bug

`build_mcp_server` failed on **private** consumer repos at the "Set up git and environment" step:

```
fatal: could not read Username for 'https://github.com': Success
Exited with code exit status 128
```

## Root cause

The job ran `set_https_remote` **before** `git fetch origin main`. CircleCI's `checkout` injects an `insteadOf` rule (HTTPS→SSH) so git operations authenticate via the deploy key. `set_https_remote` **removes that rule** and switches `origin` to literal HTTPS (needed later so pcu's commit-back in `save` uses the GitHub App token). With the rule gone, the immediately-following `git fetch` on a **private** repo had no credentials and prompted for a username → exit 128.

Public repos were unaffected (anonymous HTTPS fetch works), so gen-circleci-orb never hit this — but **circleci-toolkit (private)** did as soon as it migrated to this job.

## Fix

Reorder the steps so the fetch happens first (SSH auth still intact), then `set_https_remote` switches to HTTPS ahead of the `save`/push:

```
checkout → attach_workspace → run "Set up git and environment" (fetch)
  → set_https_remote → prime → generate → publish → save
```

Edited the `[[job_group]]` step order in `gen-circleci-orb.toml` and regenerated `orb/src/jobs/build_mcp_server.yml` (gen-circleci-orb 0.1.2, matching the pin). `circleci orb pack orb/src` → exit 0; `gen-circleci-orb update --check` → clean.

## After release

Consumers bump the `gen-orb-mcp` orb pin to pick up the fix. Immediate beneficiary: **digital-prstv/circleci-toolkit** (private) whose `circleci_toolkit_mcp` generation is currently failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
